### PR TITLE
fix: 復帰時に複数フォルダウインドウを位置とサイズ込みで復元する

### DIFF
--- a/src/SkimDown/App/AppDelegate.swift
+++ b/src/SkimDown/App/AppDelegate.swift
@@ -17,6 +17,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, NSMenu
         false
     }
 
+    func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
+        windowManager.prepareForTermination()
+        return .terminateNow
+    }
+
+    func applicationWillTerminate(_ notification: Notification) {
+        windowManager.prepareForTermination()
+    }
+
     func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
         if flag {
             windowManager.bringAllWindowsToFront()

--- a/src/SkimDown/App/DocumentWindowController.swift
+++ b/src/SkimDown/App/DocumentWindowController.swift
@@ -21,6 +21,7 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, Side
     private var session: FolderSession?
     private var fileWatcher = FileWatcher()
     private var settings: AppSettings
+    private(set) var currentFolderBookmarkData: Data?
 
     var isEmpty: Bool {
         session == nil
@@ -87,7 +88,7 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, Side
         windowManager?.controllerDidClose(self)
     }
 
-    func placeWindowOnActiveScreenIfNeeded() {
+    func placeWindowOnActiveScreenIfNeeded(preserveOnScreenFrame: Bool = false) {
         guard let window else {
             return
         }
@@ -108,7 +109,17 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, Side
         )
         let targetFrame = NSRect(origin: origin, size: preferredSize)
 
-        if !visibleFrame.intersects(window.frame) || !window.isVisible {
+        let isOffScreen = !visibleFrame.intersects(window.frame)
+        let needsRepositioning: Bool
+        if preserveOnScreenFrame {
+            // Restored windows: only intervene if the saved frame is now
+            // outside any screen (e.g. the user disconnected a display).
+            needsRepositioning = isOffScreen
+        } else {
+            needsRepositioning = isOffScreen || !window.isVisible
+        }
+
+        if needsRepositioning {
             window.setFrame(targetFrame, display: true)
         }
     }
@@ -118,6 +129,8 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, Side
             let bookmark = try bookmarkData ?? bookmarkStore.bookmarkData(for: folderURL)
             settingsStore.recordRecentFolderBookmark(bookmark)
             try loadFolder(folderURL: folderURL, preferredSelection: nil)
+            currentFolderBookmarkData = bookmark
+            windowManager?.persistOpenFolderState()
         } catch {
             showOpenError(error)
         }

--- a/src/SkimDown/App/WindowManager.swift
+++ b/src/SkimDown/App/WindowManager.swift
@@ -30,9 +30,14 @@ final class WindowManager {
             restoredAny = true
         }
 
-        if restoredAny {
-            // Re-persist so any unresolved bookmarks are dropped from storage.
+        if !openStates.isEmpty {
+            // Re-persist (potentially as an empty list) so unresolved bookmarks
+            // are dropped from storage even when zero windows were restored.
+            // Otherwise the same dead entries would be retried on every launch.
             persistOpenFolderState()
+        }
+
+        if restoredAny {
             return
         }
 

--- a/src/SkimDown/App/WindowManager.swift
+++ b/src/SkimDown/App/WindowManager.swift
@@ -5,6 +5,7 @@ final class WindowManager {
     private let settingsStore: SettingsStore
     private let bookmarkStore: FolderBookmarkStore
     private var controllers: [DocumentWindowController] = []
+    private var isTerminating = false
 
     init(settingsStore: SettingsStore, bookmarkStore: FolderBookmarkStore) {
         self.settingsStore = settingsStore
@@ -16,6 +17,27 @@ final class WindowManager {
     }
 
     func restoreOrCreateInitialWindow() {
+        let openStates = settingsStore.openFolderStates
+        var restoredAny = false
+
+        for state in openStates {
+            guard let url = try? bookmarkStore.resolveBookmarkData(state.bookmark) else {
+                continue
+            }
+            let initialFrame: CGRect? = state.frame == .zero ? nil : state.frame
+            let controller = createWindow(initialFrame: initialFrame)
+            controller.openFolder(url, bookmarkData: state.bookmark)
+            restoredAny = true
+        }
+
+        if restoredAny {
+            // Re-persist so any unresolved bookmarks are dropped from storage.
+            persistOpenFolderState()
+            return
+        }
+
+        // Backward-compatible fallback for users upgrading from a build that
+        // only tracked the single most-recent folder.
         if let bookmark = settingsStore.lastFolderBookmark,
            let url = try? bookmarkStore.resolveBookmarkData(bookmark) {
             let controller = createWindow()
@@ -27,11 +49,17 @@ final class WindowManager {
     }
 
     @discardableResult
-    func createWindow() -> DocumentWindowController {
+    func createWindow(initialFrame: CGRect? = nil) -> DocumentWindowController {
         let controller = DocumentWindowController(settingsStore: settingsStore, bookmarkStore: bookmarkStore, windowManager: self)
         controllers.append(controller)
+        if let initialFrame, let window = controller.window {
+            // Apply the persisted frame before the window is shown so that
+            // `placeWindowOnActiveScreenIfNeeded()` can use it to decide
+            // whether the saved position is still on-screen.
+            window.setFrame(initialFrame, display: false)
+        }
         controller.showWindow(nil)
-        present(controller)
+        present(controller, preserveOnScreenFrame: initialFrame != nil)
         return controller
     }
 
@@ -66,6 +94,34 @@ final class WindowManager {
 
     func controllerDidClose(_ controller: DocumentWindowController) {
         controllers.removeAll { $0 === controller }
+        // While the app is terminating, AppKit closes every window in turn.
+        // We must not let those closures shrink the persisted open-folder list
+        // (otherwise the next launch only restores the last surviving window).
+        // The snapshot was already written in `prepareForTermination()`.
+        guard !isTerminating else {
+            return
+        }
+        persistOpenFolderState()
+    }
+
+    func persistOpenFolderState() {
+        settingsStore.openFolderStates = controllers.compactMap { controller in
+            guard let bookmark = controller.currentFolderBookmarkData,
+                  let frame = controller.window?.frame else {
+                return nil
+            }
+            return OpenFolderState(bookmark: bookmark, frame: frame)
+        }
+    }
+
+    /// Capture the current set of open folders and freeze the persisted state
+    /// so that the in-flight window closures during termination don't clobber it.
+    func prepareForTermination() {
+        guard !isTerminating else {
+            return
+        }
+        persistOpenFolderState()
+        isTerminating = true
     }
 
     private func showError(_ message: String) {
@@ -76,11 +132,11 @@ final class WindowManager {
         alert.runModal()
     }
 
-    private func present(_ controller: DocumentWindowController) {
+    private func present(_ controller: DocumentWindowController, preserveOnScreenFrame: Bool = false) {
         guard let window = controller.window else {
             return
         }
-        controller.placeWindowOnActiveScreenIfNeeded()
+        controller.placeWindowOnActiveScreenIfNeeded(preserveOnScreenFrame: preserveOnScreenFrame)
         window.deminiaturize(nil)
         window.makeKeyAndOrderFront(nil)
         window.orderFrontRegardless()

--- a/src/SkimDown/Core/SettingsStore.swift
+++ b/src/SkimDown/Core/SettingsStore.swift
@@ -4,6 +4,8 @@ final class SettingsStore {
     private enum Key {
         static let lastFolderBookmark = "lastFolderBookmark"
         static let recentFolderBookmarks = "recentFolderBookmarks"
+        static let openFolderBookmarks = "openFolderBookmarks"
+        static let openFolderStates = "openFolderStates"
         static let lastSelectedMarkdownByFolder = "lastSelectedMarkdownByFolder"
         static let expandedTreeItemsByFolder = "expandedTreeItemsByFolder"
         static let sidebarPosition = "sidebarPosition"
@@ -49,6 +51,38 @@ final class SettingsStore {
     var recentFolderBookmarks: [Data] {
         get { defaults.array(forKey: Key.recentFolderBookmarks) as? [Data] ?? [] }
         set { defaults.set(newValue, forKey: Key.recentFolderBookmarks) }
+    }
+
+    /// Bookmarks for folders currently open in active windows.
+    ///
+    /// This is independent of `recentFolderBookmarks` / `lastFolderBookmark`
+    /// (which represent history) and reflects the live state of open windows
+    /// so that all of them can be restored on next launch.
+    var openFolderBookmarks: [Data] {
+        get { defaults.array(forKey: Key.openFolderBookmarks) as? [Data] ?? [] }
+        set { defaults.set(newValue, forKey: Key.openFolderBookmarks) }
+    }
+
+    /// Persisted state for each currently-open folder window: the folder
+    /// bookmark plus the on-screen frame, so windows are restored at the
+    /// same position and size on next launch.
+    ///
+    /// Falls back to legacy `openFolderBookmarks` when no states have been
+    /// written yet (one-time migration). Writing clears the legacy key.
+    var openFolderStates: [OpenFolderState] {
+        get {
+            if let raw = defaults.array(forKey: Key.openFolderStates) as? [[String: Any]] {
+                return raw.compactMap(OpenFolderState.init(dictionary:))
+            }
+            // Legacy migration: bookmarks-only storage without frames.
+            return openFolderBookmarks.map { OpenFolderState(bookmark: $0, frame: .zero) }
+        }
+        set {
+            let raw = newValue.map { $0.dictionaryRepresentation }
+            defaults.set(raw, forKey: Key.openFolderStates)
+            // Drop the legacy single-key list so we don't double-restore.
+            defaults.removeObject(forKey: Key.openFolderBookmarks)
+        }
     }
 
     var sidebarPosition: SidebarPosition {

--- a/src/SkimDown/Models/OpenFolderState.swift
+++ b/src/SkimDown/Models/OpenFolderState.swift
@@ -1,0 +1,59 @@
+import Foundation
+import CoreGraphics
+
+/// Persisted state for a single open folder window: the folder bookmark and
+/// the on-screen frame the window had when last persisted, so that windows
+/// can be restored at the same position and size on next launch.
+struct OpenFolderState: Equatable {
+    let bookmark: Data
+    let frame: CGRect
+
+    private enum DictionaryKey {
+        static let bookmark = "bookmark"
+        static let frame = "frame"
+    }
+
+    var dictionaryRepresentation: [String: Any] {
+        [
+            DictionaryKey.bookmark: bookmark,
+            DictionaryKey.frame: Self.encode(frame: frame)
+        ]
+    }
+
+    init(bookmark: Data, frame: CGRect) {
+        self.bookmark = bookmark
+        self.frame = frame
+    }
+
+    init?(dictionary: [String: Any]) {
+        guard let bookmark = dictionary[DictionaryKey.bookmark] as? Data else {
+            return nil
+        }
+        let frame: CGRect
+        if let frameString = dictionary[DictionaryKey.frame] as? String,
+           let decoded = Self.decode(frameString: frameString) {
+            frame = decoded
+        } else {
+            frame = .zero
+        }
+        self.bookmark = bookmark
+        self.frame = frame
+    }
+
+    private static func encode(frame: CGRect) -> String {
+        "\(frame.origin.x),\(frame.origin.y),\(frame.size.width),\(frame.size.height)"
+    }
+
+    private static func decode(frameString: String) -> CGRect? {
+        let parts = frameString.split(separator: ",")
+        guard parts.count == 4,
+              let x = Double(parts[0]),
+              let y = Double(parts[1]),
+              let w = Double(parts[2]),
+              let h = Double(parts[3]) else {
+            return nil
+        }
+        return CGRect(x: x, y: y, width: w, height: h)
+    }
+}
+

--- a/src/SkimDownTests/SettingsStoreTests.swift
+++ b/src/SkimDownTests/SettingsStoreTests.swift
@@ -46,5 +46,107 @@ final class SettingsStoreTests: XCTestCase {
         XCTAssertEqual(store.lastSelectedMarkdownRelativePath(for: folder.url), "Docs/doc.md")
         XCTAssertEqual(store.expandedTreeItemRelativePaths(for: folder.url), ["Docs"])
     }
+
+    func testOpenFolderBookmarksRoundTrip() throws {
+        let suiteName = "dev.jp27.SkimDownTests.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer {
+            defaults.removePersistentDomain(forName: suiteName)
+        }
+
+        let store = SettingsStore(defaults: defaults)
+        XCTAssertTrue(store.openFolderBookmarks.isEmpty)
+
+        let bookmarkA = Data([0x01, 0x02, 0x03])
+        let bookmarkB = Data([0x10, 0x20, 0x30, 0x40])
+        store.openFolderBookmarks = [bookmarkA, bookmarkB]
+
+        let reloaded = SettingsStore(defaults: defaults)
+        XCTAssertEqual(reloaded.openFolderBookmarks, [bookmarkA, bookmarkB])
+
+        reloaded.openFolderBookmarks = []
+        XCTAssertTrue(SettingsStore(defaults: defaults).openFolderBookmarks.isEmpty)
+    }
+
+    func testOpenFolderBookmarksAreIndependentOfRecentAndLast() throws {
+        let suiteName = "dev.jp27.SkimDownTests.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer {
+            defaults.removePersistentDomain(forName: suiteName)
+        }
+
+        let store = SettingsStore(defaults: defaults)
+        let bookmark = Data([0xAA, 0xBB])
+        store.recordRecentFolderBookmark(bookmark)
+
+        XCTAssertEqual(store.lastFolderBookmark, bookmark)
+        XCTAssertEqual(store.recentFolderBookmarks, [bookmark])
+        XCTAssertTrue(store.openFolderBookmarks.isEmpty,
+                      "Recording a recent bookmark must not implicitly add it to openFolderBookmarks")
+        XCTAssertTrue(store.openFolderStates.isEmpty,
+                      "Recording a recent bookmark must not implicitly add it to openFolderStates")
+    }
+
+    func testOpenFolderStatesRoundTripPreservesFrames() throws {
+        let suiteName = "dev.jp27.SkimDownTests.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer {
+            defaults.removePersistentDomain(forName: suiteName)
+        }
+
+        let store = SettingsStore(defaults: defaults)
+        XCTAssertTrue(store.openFolderStates.isEmpty)
+
+        let stateA = OpenFolderState(
+            bookmark: Data([0x01, 0x02]),
+            frame: CGRect(x: 100, y: 200, width: 1024, height: 768)
+        )
+        let stateB = OpenFolderState(
+            bookmark: Data([0x03, 0x04]),
+            frame: CGRect(x: -50, y: 0, width: 960, height: 660)
+        )
+        store.openFolderStates = [stateA, stateB]
+
+        let reloaded = SettingsStore(defaults: defaults)
+        XCTAssertEqual(reloaded.openFolderStates, [stateA, stateB])
+    }
+
+    func testWritingOpenFolderStatesClearsLegacyBookmarksKey() throws {
+        let suiteName = "dev.jp27.SkimDownTests.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer {
+            defaults.removePersistentDomain(forName: suiteName)
+        }
+
+        let store = SettingsStore(defaults: defaults)
+        store.openFolderBookmarks = [Data([0x10]), Data([0x20])]
+        XCTAssertEqual(store.openFolderBookmarks.count, 2)
+
+        store.openFolderStates = [
+            OpenFolderState(bookmark: Data([0x10]), frame: CGRect(x: 0, y: 0, width: 1024, height: 768))
+        ]
+
+        XCTAssertTrue(store.openFolderBookmarks.isEmpty,
+                      "Writing openFolderStates must clear the legacy openFolderBookmarks key")
+        XCTAssertEqual(store.openFolderStates.count, 1)
+    }
+
+    func testOpenFolderStatesMigratesFromLegacyBookmarksWithZeroFrame() throws {
+        let suiteName = "dev.jp27.SkimDownTests.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer {
+            defaults.removePersistentDomain(forName: suiteName)
+        }
+
+        let legacyA = Data([0xAA])
+        let legacyB = Data([0xBB])
+        let store = SettingsStore(defaults: defaults)
+        store.openFolderBookmarks = [legacyA, legacyB]
+
+        let migrated = store.openFolderStates
+        XCTAssertEqual(migrated.map(\.bookmark), [legacyA, legacyB])
+        XCTAssertTrue(migrated.allSatisfy { $0.frame == .zero },
+                      "Legacy bookmarks have no frame and should migrate as .zero")
+    }
 }
 


### PR DESCRIPTION
## 概要

複数フォルダ（ウインドウ）を開いた状態で `Cmd + Q` 終了し、再度 SkimDown を起動すると最後に開いたフォルダしか復元されない問題を修正します。あわせて、各ウインドウの位置とサイズも記憶・復元するようにします。

## 再現

1. SkimDown でフォルダ A, B, C をそれぞれ別ウインドウで開く
2. \`Cmd + Q\` で終了
3. 再度 SkimDown を起動 → ウインドウが 1 つしか出てこない（期待: A, B, C すべて）

## 原因

- \`SettingsStore\` には単一の \`lastFolderBookmark\` しか永続化していなかった
- 終了時に AppKit が各ウインドウを順に閉じる過程で \`windowWillClose\` → \`controllerDidClose\` → \`persistOpenFolderState()\` が連鎖し、保存リストがウインドウクローズの度に縮んで最終的に空になっていた
- 起動時のフォールバックで \`lastFolderBookmark\` の 1 件だけが復元されていた

## 修正

- 新モデル \`OpenFolderState { bookmark: Data; frame: CGRect }\` を追加し、\`SettingsStore.openFolderStates: [OpenFolderState]\` で複数ウインドウの状態（フォルダ + フレーム）を永続化
- 旧 \`openFolderBookmarks\` キーからの自動マイグレーション（\`.zero\` フレームで取り込み）と、新キー書き込み時の旧キー削除を実装
- \`WindowManager.prepareForTermination()\` を追加し、\`applicationShouldTerminate(_:)\`（ウインドウクローズより前）でスナップショット保存。以降 \`controllerDidClose\` での persist はスキップしてレースを排除
- \`WindowManager.createWindow(initialFrame:)\` で復元時に \`window.setFrame(_, display: false)\` してから present
- \`DocumentWindowController.placeWindowOnActiveScreenIfNeeded(preserveOnScreenFrame:)\` を追加し、復元したウインドウは画面外でない限りそのフレームを尊重（外部ディスプレイ取り外し時は中央に救済）
- 空ウインドウ（\`Cmd+N\` のみで作ったフォルダ未指定状態）は復元対象外

## 動作確認

- \`make test\` : 25 件すべて PASS（追加 4・更新 1）
  - \`testOpenFolderStatesRoundTripPreservesFrames\`
  - \`testWritingOpenFolderStatesClearsLegacyBookmarksKey\`
  - \`testOpenFolderStatesMigratesFromLegacyBookmarksWithZeroFrame\`
  - \`testOpenFolderBookmarksAreIndependentOfRecentAndLast\`（既存に states 独立性アサート追加）
  - \`testOpenFolderBookmarksRoundTrip\`（互換）
- \`make launch-check\` : PASS
- 手動: 3 ウインドウを別位置・別サイズで配置 → \`Cmd+Q\` → 再起動で全ウインドウが終了前のフレームで復元されることを確認

## 関連ファイル

- 新規: \`src/SkimDown/Models/OpenFolderState.swift\`
- 変更: \`src/SkimDown/Core/SettingsStore.swift\`, \`src/SkimDown/App/WindowManager.swift\`, \`src/SkimDown/App/DocumentWindowController.swift\`, \`src/SkimDown/App/AppDelegate.swift\`
- テスト: \`src/SkimDownTests/SettingsStoreTests.swift\`