### PR TITLE
fix: サイドバーのドラッグ幅変更が反映されないバグを修正

### DIFF
--- a/src/SkimDown/App/DocumentWindowController.swift
+++ b/src/SkimDown/App/DocumentWindowController.swift
@@ -23,6 +23,14 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, Side
     private var settings: AppSettings
     private(set) var currentFolderBookmarkData: Data?
 
+    /// コンテンツ側 (defaultLow = 250) がリサイズを引き受けるよう、
+    /// サイドバー側だけ一段高い保持優先度を割り当てる。これにより
+    /// ドラッグ終了直後の Auto Layout 再解決でサイドバー幅が
+    /// スナップバックしないようにする。
+    private static let sidebarHoldingPriority = NSLayoutConstraint.Priority(
+        rawValue: NSLayoutConstraint.Priority.defaultLow.rawValue + 10
+    )
+
     var isEmpty: Bool {
         session == nil
     }
@@ -361,7 +369,7 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, Side
         sidebarItem.minimumThickness = 180
         sidebarItem.maximumThickness = 520
         sidebarItem.canCollapse = true
-        sidebarItem.holdingPriority = NSLayoutConstraint.Priority(rawValue: 260)
+        sidebarItem.holdingPriority = Self.sidebarHoldingPriority
         sidebarItem.isCollapsed = !settings.isSidebarVisible
 
         contentItem = NSSplitViewItem(viewController: documentContentViewController)

--- a/src/SkimDown/App/DocumentWindowController.swift
+++ b/src/SkimDown/App/DocumentWindowController.swift
@@ -361,6 +361,7 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, Side
         sidebarItem.minimumThickness = 180
         sidebarItem.maximumThickness = 520
         sidebarItem.canCollapse = true
+        sidebarItem.holdingPriority = NSLayoutConstraint.Priority(rawValue: 260)
         sidebarItem.isCollapsed = !settings.isSidebarVisible
 
         contentItem = NSSplitViewItem(viewController: documentContentViewController)
@@ -376,13 +377,12 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, Side
     }
 
     @objc private func splitViewDidResizeSubviewsNotification(_ notification: Notification) {
-        guard !sidebarItem.isCollapsed, splitViewController.splitView.subviews.count == 2 else {
+        guard !sidebarItem.isCollapsed,
+              splitViewController.splitViewItems.count == 2 else {
             return
         }
 
-        let splitView = splitViewController.splitView
-        let sidebarIndex = settings.sidebarPosition == .left ? 0 : 1
-        let width = splitView.subviews[sidebarIndex].bounds.width
+        let width = sidebarItem.viewController.view.bounds.width
         guard width > 0 else {
             return
         }
@@ -411,15 +411,12 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, Side
     }
 
     private func applySidebarWidth() {
-        guard !sidebarItem.isCollapsed else {
+        guard !sidebarItem.isCollapsed,
+              splitViewController.splitViewItems.count == 2 else {
             return
         }
 
         let splitView = splitViewController.splitView
-        guard splitView.subviews.count == 2 else {
-            return
-        }
-
         if settings.sidebarPosition == .left {
             splitView.setPosition(settings.sidebarWidth, ofDividerAt: 0)
         } else {


### PR DESCRIPTION
## 概要

サイドバー（ツリービュー）とプレビュー領域の境界ディバイダを
ドラッグして幅を変更しても、マウスを離すと元の幅にスナップバックする
問題を修正する。

## 原因

2 つの問題が重なっていた。

### 1. 通知ハンドラの早期 return

`splitViewDidResizeSubviewsNotification(_:)` と `applySidebarWidth()` の
ガード `splitView.subviews.count == 2` が実機では常に偽になっていた。

`NSSplitViewController` は divider 等の補助ビューを内部的に
\`splitView.subviews\` に持つため、実機での値は **3**（サイドバー collapse 後は **4**）。
ハンドラが常に早期 return していたため、ドラッグ後の幅が
`settings.sidebarWidth` / `UserDefaults` に永続化されていなかった。

### 2. holdingPriority 未設定によるレイアウト再解決

`NSSplitViewItem.holdingPriority` がサイドバー / コンテンツ両方
デフォルト (`NSLayoutPriorityDefaultLow` = 250) のままだった。
両ペインが同じ優先度の場合、ドラッグ終了直後の Auto Layout レイアウトパスで
サイドバー幅が再計算され、見た目だけ別の値（実質 `minimumThickness` か
`maximumThickness`）にスナップしていた。

## 修正

\`src/SkimDown/App/DocumentWindowController.swift\` のみ。

- ガードを `splitViewItems.count == 2` に変更し、幅は
  `sidebarItem.viewController.view.bounds.width` 経由で取得。
- `sidebarItem.holdingPriority = NSLayoutConstraint.Priority(rawValue: 260)`
  を追加し、コンテンツ側がサイズ変更を引き受ける構成を明示。

## 検証

- `make build` ✅
- `make test`（25 件）✅
- 手動: 任意のフォルダを開く → サイドバー幅を中間位置にドラッグ →
  マウスを離した後も幅が維持されることを確認。
- 手動: アプリ再起動後も幅が復元されることを確認。