### PR TITLE
Remember scroll position per file across navigation

### DIFF
--- a/src/SkimDown/App/DocumentWindowController.swift
+++ b/src/SkimDown/App/DocumentWindowController.swift
@@ -522,11 +522,12 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, Side
         let isDifferentFile = previousCanonical != canonicalNew
 
         if isDifferentFile, let previousCanonical {
-            let observed = markdownWebView.currentObservedScrollY
-            if observed > 0 {
-                scrollPositions[previousCanonical] = observed
-            } else {
-                scrollPositions.removeValue(forKey: previousCanonical)
+            if let observed = markdownWebView.currentObservedScrollY {
+                if observed > 0 {
+                    scrollPositions[previousCanonical] = observed
+                } else {
+                    scrollPositions.removeValue(forKey: previousCanonical)
+                }
             }
         }
 

--- a/src/SkimDown/App/DocumentWindowController.swift
+++ b/src/SkimDown/App/DocumentWindowController.swift
@@ -22,6 +22,7 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, Side
     private var fileWatcher = FileWatcher()
     private var settings: AppSettings
     private(set) var currentFolderBookmarkData: Data?
+    private var scrollPositions: [URL: Double] = [:]
 
     /// コンテンツ側 (defaultLow = 250) がリサイズを引き受けるよう、
     /// サイドバー側だけ一段高い保持優先度を割り当てる。これにより
@@ -439,6 +440,7 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, Side
         let lastRelativePath = preferredSelection.flatMap { PathSecurity.relativePath(for: $0, in: folderURL) } ?? settingsStore.lastSelectedMarkdownRelativePath(for: folderURL)
         let selectedFile = InitialSelectionResolver().resolve(folderURL: folderURL, markdownFiles: markdownFiles, treeItems: treeItems, lastRelativePath: lastRelativePath)
 
+        scrollPositions.removeAll()
         session = FolderSession(folderURL: folderURL, treeItems: treeItems, markdownFiles: markdownFiles, selectedFileURL: selectedFile)
         window?.title = "\(folderURL.lastPathComponent) \u{2014} SkimDown"
 
@@ -488,6 +490,9 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, Side
             session.markdownFiles = markdownFiles
             session.selectedFileURL = stillSelected
 
+            let liveCanonicalURLs = Set(markdownFiles.map(\.skimdownCanonicalFileURL))
+            scrollPositions = scrollPositions.filter { liveCanonicalURLs.contains($0.key) }
+
             sidebarViewController.update(
                 folderName: folderURL.skimdownDisplayName,
                 markdownCount: markdownFiles.count,
@@ -512,11 +517,35 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, Side
             return
         }
 
+        let canonicalNew = fileURL.skimdownCanonicalFileURL
+        let previousCanonical = session.selectedFileURL?.skimdownCanonicalFileURL
+        let isDifferentFile = previousCanonical != canonicalNew
+
+        if isDifferentFile, let previousCanonical {
+            let observed = markdownWebView.currentObservedScrollY
+            if observed > 0 {
+                scrollPositions[previousCanonical] = observed
+            } else {
+                scrollPositions.removeValue(forKey: previousCanonical)
+            }
+        }
+
+        performSelectFile(fileURL, anchor: anchor, preserveScrollPosition: preserveScrollPosition, isDifferentFile: isDifferentFile)
+    }
+
+    private func performSelectFile(_ fileURL: URL, anchor: String?, preserveScrollPosition: Bool, isDifferentFile: Bool) {
+        guard let session, PathSecurity.isFileURL(fileURL, containedIn: session.folderURL) else {
+            NSSound.beep()
+            return
+        }
+
         do {
             let canonicalFileURL = fileURL.skimdownCanonicalFileURL
             let shouldPreserveScrollPosition = preserveScrollPosition
                 && anchor == nil
-                && session.selectedFileURL?.skimdownCanonicalFileURL == canonicalFileURL
+                && !isDifferentFile
+            let restoreScrollY: Double? = (anchor == nil && isDifferentFile) ? scrollPositions[canonicalFileURL] : nil
+            let preservesViewport = shouldPreserveScrollPosition || restoreScrollY != nil
             let markdown = try MarkdownDocumentLoader().load(fileURL: fileURL)
             session.selectedFileURL = canonicalFileURL
             settingsStore.setLastSelectedMarkdown(fileURL, for: session.folderURL)
@@ -529,9 +558,10 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, Side
                 rootFolderURL: session.folderURL,
                 theme: settings.theme,
                 fontSize: settings.fontSize,
-                preserveScrollPosition: shouldPreserveScrollPosition
+                preserveScrollPosition: shouldPreserveScrollPosition,
+                restoreScrollY: restoreScrollY
             ) { [weak self] in
-                self?.completeMarkdownRender(anchor: anchor, preservesScrollPosition: shouldPreserveScrollPosition)
+                self?.completeMarkdownRender(anchor: anchor, preservesViewport: preservesViewport)
             }
         } catch {
             session.selectedFileURL = fileURL.skimdownCanonicalFileURL
@@ -549,8 +579,8 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, Side
         selectFile(selectedFileURL, anchor: nil, preserveScrollPosition: preserveScrollPosition)
     }
 
-    private func completeMarkdownRender(anchor: String?, preservesScrollPosition: Bool) {
-        performSearch(scrollToMatch: !preservesScrollPosition)
+    private func completeMarkdownRender(anchor: String?, preservesViewport: Bool) {
+        performSearch(scrollToMatch: !preservesViewport)
         if let anchor {
             markdownWebView.scrollToAnchor(anchor)
         }

--- a/src/SkimDown/App/DocumentWindowController.swift
+++ b/src/SkimDown/App/DocumentWindowController.swift
@@ -523,11 +523,7 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, Side
 
         if isDifferentFile, let previousCanonical {
             if let observed = markdownWebView.currentObservedScrollY {
-                if observed > 0 {
-                    scrollPositions[previousCanonical] = observed
-                } else {
-                    scrollPositions.removeValue(forKey: previousCanonical)
-                }
+                scrollPositions[previousCanonical] = observed
             }
         }
 

--- a/src/SkimDown/Resources/Web/renderer.js
+++ b/src/SkimDown/Resources/Web/renderer.js
@@ -64,7 +64,7 @@
     clearSearch();
 
     notifyWhenRenderSettled(content, payload.renderID, mermaidTasks, payload.awaitFullSettle === true);
-    installUserInteractionWatcher();
+    installUserInteractionWatcher(payload.renderID);
     installScrollPositionListener(payload.renderID);
   }
 
@@ -77,14 +77,14 @@
     window.addEventListener("scroll", postScroll, { passive: true });
   }
 
-  function installUserInteractionWatcher() {
+  function installUserInteractionWatcher(renderID) {
     function onInteract() {
       window.removeEventListener("wheel", onInteract, { capture: true });
       window.removeEventListener("touchstart", onInteract, { capture: true });
       window.removeEventListener("keydown", onInteract, { capture: true });
       window.removeEventListener("mousedown", onInteract, { capture: true });
       if (window.webkit && window.webkit.messageHandlers && window.webkit.messageHandlers.userInteracted) {
-        window.webkit.messageHandlers.userInteracted.postMessage({});
+        window.webkit.messageHandlers.userInteracted.postMessage({ renderID: renderID });
       }
     }
     window.addEventListener("wheel", onInteract, { capture: true, once: true, passive: true });

--- a/src/SkimDown/Resources/Web/renderer.js
+++ b/src/SkimDown/Resources/Web/renderer.js
@@ -65,6 +65,24 @@
 
     notifyWhenRenderSettled(content, payload.renderID, mermaidTasks, payload.awaitFullSettle === true);
     installUserInteractionWatcher();
+    installScrollPositionListener();
+  }
+
+  function installScrollPositionListener() {
+    let scheduled = false;
+    function postScroll() {
+      scheduled = false;
+      if (window.webkit && window.webkit.messageHandlers && window.webkit.messageHandlers.scrollPosition) {
+        window.webkit.messageHandlers.scrollPosition.postMessage({ scrollY: window.scrollY });
+      }
+    }
+    window.addEventListener("scroll", function () {
+      if (scheduled) {
+        return;
+      }
+      scheduled = true;
+      window.requestAnimationFrame(postScroll);
+    }, { passive: true });
   }
 
   function installUserInteractionWatcher() {

--- a/src/SkimDown/Resources/Web/renderer.js
+++ b/src/SkimDown/Resources/Web/renderer.js
@@ -74,7 +74,6 @@
         window.webkit.messageHandlers.scrollPosition.postMessage({ renderID: renderID, scrollY: window.scrollY });
       }
     }
-    postScroll();
     window.addEventListener("scroll", postScroll, { passive: true });
   }
 

--- a/src/SkimDown/Resources/Web/renderer.js
+++ b/src/SkimDown/Resources/Web/renderer.js
@@ -65,24 +65,17 @@
 
     notifyWhenRenderSettled(content, payload.renderID, mermaidTasks, payload.awaitFullSettle === true);
     installUserInteractionWatcher();
-    installScrollPositionListener();
+    installScrollPositionListener(payload.renderID);
   }
 
-  function installScrollPositionListener() {
-    let scheduled = false;
+  function installScrollPositionListener(renderID) {
     function postScroll() {
-      scheduled = false;
       if (window.webkit && window.webkit.messageHandlers && window.webkit.messageHandlers.scrollPosition) {
-        window.webkit.messageHandlers.scrollPosition.postMessage({ scrollY: window.scrollY });
+        window.webkit.messageHandlers.scrollPosition.postMessage({ renderID: renderID, scrollY: window.scrollY });
       }
     }
-    window.addEventListener("scroll", function () {
-      if (scheduled) {
-        return;
-      }
-      scheduled = true;
-      window.requestAnimationFrame(postScroll);
-    }, { passive: true });
+    postScroll();
+    window.addEventListener("scroll", postScroll, { passive: true });
   }
 
   function installUserInteractionWatcher() {

--- a/src/SkimDown/Viewer/MarkdownWebView.swift
+++ b/src/SkimDown/Viewer/MarkdownWebView.swift
@@ -67,7 +67,7 @@ final class MarkdownWebView: NSView, WKScriptMessageHandler, WKNavigationDelegat
     private let webView: WKWebView
     private var renderGeneration = 0
     private var pendingNavigation: PendingNavigation?
-    private var observedScrollY: Double = 0
+    private var observedScrollY: Double?
 
     override init(frame frameRect: NSRect) {
         let configuration = WKWebViewConfiguration()
@@ -167,7 +167,7 @@ final class MarkdownWebView: NSView, WKScriptMessageHandler, WKNavigationDelegat
         }
     }
 
-    var currentObservedScrollY: Double {
+    var currentObservedScrollY: Double? {
         observedScrollY
     }
 
@@ -267,6 +267,8 @@ final class MarkdownWebView: NSView, WKScriptMessageHandler, WKNavigationDelegat
             cancelPendingScrollRestoration()
         case .scrollPosition:
             guard let body = message.body as? [String: Any],
+                  let renderID = Self.intValue(body["renderID"]),
+                  renderID == renderGeneration,
                   let value = Self.doubleValue(body["scrollY"]) else {
                 return
             }
@@ -341,7 +343,7 @@ final class MarkdownWebView: NSView, WKScriptMessageHandler, WKNavigationDelegat
         guard renderGeneration == generation else {
             return
         }
-        observedScrollY = 0
+        observedScrollY = nil
         guard let navigation = webView.loadHTMLString(html, baseURL: baseURL) else {
             completion?()
             return

--- a/src/SkimDown/Viewer/MarkdownWebView.swift
+++ b/src/SkimDown/Viewer/MarkdownWebView.swift
@@ -264,6 +264,11 @@ final class MarkdownWebView: NSView, WKScriptMessageHandler, WKNavigationDelegat
             }
             markRenderReady(generation: renderID)
         case .userInteracted:
+            guard let body = message.body as? [String: Any],
+                  let renderID = Self.intValue(body["renderID"]),
+                  renderID == renderGeneration else {
+                return
+            }
             cancelPendingScrollRestoration()
         case .scrollPosition:
             guard let body = message.body as? [String: Any],

--- a/src/SkimDown/Viewer/MarkdownWebView.swift
+++ b/src/SkimDown/Viewer/MarkdownWebView.swift
@@ -381,6 +381,9 @@ final class MarkdownWebView: NSView, WKScriptMessageHandler, WKNavigationDelegat
         if let scrollY = pendingNavigation.scrollY, scrollY > 0 {
             webView.evaluateJavaScript("window.scrollTo(0, \(scrollY))")
         }
+        if observedScrollY == nil {
+            observedScrollY = pendingNavigation.scrollY ?? 0
+        }
         pendingNavigation.completion?()
     }
 

--- a/src/SkimDown/Viewer/MarkdownWebView.swift
+++ b/src/SkimDown/Viewer/MarkdownWebView.swift
@@ -36,6 +36,7 @@ final class MarkdownWebView: NSView, WKScriptMessageHandler, WKNavigationDelegat
         case copyCode
         case renderReady
         case userInteracted
+        case scrollPosition
     }
 
     private struct PendingNavigation {
@@ -66,6 +67,7 @@ final class MarkdownWebView: NSView, WKScriptMessageHandler, WKNavigationDelegat
     private let webView: WKWebView
     private var renderGeneration = 0
     private var pendingNavigation: PendingNavigation?
+    private var observedScrollY: Double = 0
 
     override init(frame frameRect: NSRect) {
         let configuration = WKWebViewConfiguration()
@@ -111,12 +113,14 @@ final class MarkdownWebView: NSView, WKScriptMessageHandler, WKNavigationDelegat
         theme: AppTheme,
         fontSize: Double,
         preserveScrollPosition: Bool = false,
+        restoreScrollY: Double? = nil,
         completion: (() -> Void)? = nil
     ) {
         let generation = advanceRenderGeneration()
         applyNativeAppearance(theme)
 
         let baseURL = currentFileURL.deletingLastPathComponent()
+        let awaitFullSettle = preserveScrollPosition || restoreScrollY != nil
         let payload = Self.renderPayload(
             markdown: markdown,
             baseURL: baseURL,
@@ -124,7 +128,7 @@ final class MarkdownWebView: NSView, WKScriptMessageHandler, WKNavigationDelegat
             theme: theme,
             fontSize: fontSize,
             generation: generation,
-            awaitFullSettle: preserveScrollPosition
+            awaitFullSettle: awaitFullSettle
         )
 
         let html: String
@@ -142,6 +146,12 @@ final class MarkdownWebView: NSView, WKScriptMessageHandler, WKNavigationDelegat
             return
         }
 
+        if let restoreScrollY {
+            let target = restoreScrollY > 0 ? restoreScrollY : nil
+            loadHTML(html, baseURL: baseURL, generation: generation, scrollY: target, completion: completion)
+            return
+        }
+
         guard preserveScrollPosition else {
             loadHTML(html, baseURL: baseURL, generation: generation, scrollY: nil, completion: completion)
             return
@@ -155,6 +165,10 @@ final class MarkdownWebView: NSView, WKScriptMessageHandler, WKNavigationDelegat
             }
             self.loadHTML(html, baseURL: baseURL, generation: generation, scrollY: Self.doubleValue(value), completion: completion)
         }
+    }
+
+    var currentObservedScrollY: Double {
+        observedScrollY
     }
 
     func showError(_ message: String, theme: AppTheme, fontSize: Double, completion: (() -> Void)? = nil) {
@@ -251,6 +265,12 @@ final class MarkdownWebView: NSView, WKScriptMessageHandler, WKNavigationDelegat
             markRenderReady(generation: renderID)
         case .userInteracted:
             cancelPendingScrollRestoration()
+        case .scrollPosition:
+            guard let body = message.body as? [String: Any],
+                  let value = Self.doubleValue(body["scrollY"]) else {
+                return
+            }
+            observedScrollY = value
         }
     }
 
@@ -321,6 +341,7 @@ final class MarkdownWebView: NSView, WKScriptMessageHandler, WKNavigationDelegat
         guard renderGeneration == generation else {
             return
         }
+        observedScrollY = 0
         guard let navigation = webView.loadHTMLString(html, baseURL: baseURL) else {
             completion?()
             return


### PR DESCRIPTION
## Summary
ファイル間を行き来したとき、戻ったファイルの **前回離れた位置** にビューポートを復帰させる機能を追加します（セッション内インメモリ、アプリ再起動でリセット）。

## Behavior
- ファイル A を下までスクロール → ファイル B を選択 → 再びファイル A を選択 ⇒ A が前回位置に復帰。
- アンカー付きリンク（`other.md#sec`）は anchor 優先、保存位置は無視。
- 復元中にユーザーが手動操作（wheel / touch / key / mousedown）すれば即キャンセル（PR #16 の `userInteracted` 機構を再利用）。
- フォルダを開き直す／別フォルダに切替えると履歴クリア。スキャンで消えたファイルのエントリも自動掃除。
- 同一ファイルの auto-refresh / theme・font 変更は従来通り `preserveScrollPosition` 経路で別管理（regression なし）。

## Implementation
- `MarkdownWebView`
  - `renderer.js` から `scrollPosition` メッセージを受信し、`observedScrollY` を同期更新。`loadHTML` 開始時にリセット。
  - `render(...)` に `restoreScrollY: Double?` を追加。指定時は `awaitFullSettle: true` で payload を組み、`PendingNavigation.scrollY` 経由で復元（既存 full-settle 待機 + ユーザー操作キャンセルを再利用）。
  - 公開ゲッタ `currentObservedScrollY` を追加。
- `DocumentWindowController`
  - `scrollPositions: [URL: Double]` をセッション内保持（キーは `skimdownCanonicalFileURL`）。
  - `selectFile(...)` で **異なるファイル** に遷移する直前に `currentObservedScrollY` を**同期**読み出して `scrollPositions[prev]` に保存。
  - `performSelectFile(...)` で anchor 無し & 異なるファイル & 辞書ヒット時に `restoreScrollY` を組み立て。
  - `loadFolder` で全クリア、`reloadFolderAfterChange` で消えたファイルを掃除。
- `renderer.js`: `installScrollPositionListener(renderID)` で `scroll` イベント発生ごとに即 native へ post（throttle なし。ブラウザが scroll 配信自体を frame cadence に coalesce するため過剰負荷にはならず、`requestAnimationFrame` を挟むと最新値到達前にユーザーが他ファイルへクリックする race を生むため撤廃）。`scrollPosition` / `userInteracted` 双方の payload に現在の `renderID` を同梱し、native 側で `renderGeneration` と一致するメッセージのみ処理することで、前ページからの遅延メッセージによる汚染やキャンセルを防いでいる。

### Race-free design
当初 `Task` 内 `evaluateJavaScript` で非同期キャプチャする実装も検討しましたが、A→B→C の高速クリックで「B のレンダ中に A 側のキャプチャが webview の B の scrollY を読んで dict[A] を上書き」する race を発見。`scroll` イベントを native にプッシュして同期で読み出す方式に切替えています。

## Validation
- `make test` 通過（31 / 31）
- `make launch-check` 通過
- 手動シナリオ：
  1. A スクロール → B → A ⇒ 復帰
  2. A → A#sec ⇒ アンカーへジャンプ（保存値無視）
  3. A → B → A → 直後に手動スクロール ⇒ 復元キャンセル、手動位置維持
  4. 別フォルダ ↔ 元フォルダ ⇒ 辞書クリアで先頭から
  5. 同一ファイル auto-refresh ⇒ 既存 preserveScrollPosition で従来通り

## Dependencies
このブランチは **PR #16** (`copilot/fix-auto-scroll-behavior`) を base にしています。理由: 本機能の復元経路は PR #16 で追加した `awaitFullSettle` / `userInteracted` キャンセル機構に依存するため。PR #16 がマージされたら main へ rebase します。

## Out of scope
- アプリ再起動を跨ぐ永続化（`SettingsStore` 拡張）
- マルチウィンドウ間の共有

