### PR TITLE
fix(ci): trigger docs deploy via workflow_run on Release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,15 @@ name: CI
 on:
   pull_request:
     branches: [main]
+    paths-ignore:
+      - 'docs/**'
+      - 'design/**'
+      - 'samples/**'
+      - '**/*.md'
+      - 'icon.png'
+      - 'LICENSE'
+      - '.gitignore'
+      - '.env.example'
 
 concurrency:
   group: ci-${{ github.ref }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,15 +3,6 @@ name: CI
 on:
   pull_request:
     branches: [main]
-    paths-ignore:
-      - 'docs/**'
-      - 'design/**'
-      - 'samples/**'
-      - '**/*.md'
-      - 'icon.png'
-      - 'LICENSE'
-      - '.gitignore'
-      - '.env.example'
 
 concurrency:
   group: ci-${{ github.ref }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,8 +1,9 @@
 name: Deploy Docs
 
 on:
-  release:
-    types: [published]
+  workflow_run:
+    workflows: ['Release']
+    types: [completed]
   workflow_dispatch:
 
 permissions:
@@ -17,6 +18,9 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    # When triggered by workflow_run, only deploy if the upstream Release
+    # workflow succeeded. workflow_dispatch runs always proceed.
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,6 +4,8 @@ on:
   workflow_run:
     workflows: ['Release']
     types: [completed]
+  release:
+    types: [published]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: main
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
## 概要

App Release を作成しても Docs のデプロイワークフローが起動しない問題を修正します。

## 原因

`release.yml` は `softprops/action-gh-release` で Release を作成していますが、認証にデフォルトの `GITHUB_TOKEN` を使っています。GitHub Actions の仕様上、`GITHUB_TOKEN` 由来で発生したイベント（push / release など）は **他のワークフローをトリガーしません**（無限ループ防止のための安全機構）。

その結果、`docs.yml` の `release: published` トリガーが永遠に発火せず、Docs のデプロイが走らない状態でした。

参考: [Triggering a workflow from a workflow](https://docs.github.com/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow)

## 変更内容 (`.github/workflows/docs.yml`)

- トリガーに `workflow_run` (`Release` ワークフロー完了時) を追加 — これが `GITHUB_TOKEN` 経由のリリースを拾う本命の経路
- `release: published` トリガーは**残す** — UI / PAT 等で手動作成された Release も従来どおり拾える（`GITHUB_TOKEN` 由来は元々発火しないので二重デプロイにならない）
- `workflow_dispatch` も維持（手動デプロイ可）
- `build` ジョブに `if: github.event.workflow_run.conclusion == 'success'` ガードを追加（失敗リリース時はデプロイしない）
- `actions/checkout` に `with: ref: main` を明示 — Docs サイトはタグ単位でバージョニングしないため、両トリガー経路で常に main の最新を deploy する

## 動作

| 契機 | Docs 自動デプロイ |
| --- | --- |
| タグ push → `release.yml` 成功 → `workflow_run` | ✅ |
| タグ push → `release.yml` 失敗 | ❌（意図どおり） |
| UI / PAT で手動 Release 作成 → `release: published` | ✅ |
| 手動 `workflow_dispatch` | ✅ |
