### PR TITLE
Fix section anchor links

### DIFF
--- a/src/SkimDown/Resources/Web/renderer.js
+++ b/src/SkimDown/Resources/Web/renderer.js
@@ -106,6 +106,7 @@
       ALLOW_DATA_ATTR: false
     });
 
+    assignHeadingAnchorIDs(content);
     convertAlerts(content);
     normalizeTaskLists(content);
     normalizeLinksAndImages(content, payload);
@@ -235,6 +236,47 @@
       item.classList.add("task-list-item");
       item.insertBefore(checkbox, item.firstChild);
     });
+  }
+
+  function assignHeadingAnchorIDs(content) {
+    const usedIDs = new Set();
+    content.querySelectorAll("[id]").forEach(function (element) {
+      const id = element.getAttribute("id");
+      if (id) {
+        usedIDs.add(id);
+      }
+    });
+
+    content.querySelectorAll("h1, h2, h3, h4, h5, h6").forEach(function (heading) {
+      if (heading.getAttribute("id")) {
+        return;
+      }
+
+      const baseID = slugifyHeadingText(heading.textContent || "") || "section";
+      const id = uniqueHeadingID(baseID, usedIDs);
+      heading.setAttribute("id", id);
+      usedIDs.add(id);
+    });
+  }
+
+  function slugifyHeadingText(text) {
+    return String(text)
+      .trim()
+      .toLowerCase()
+      .replace(/[^\p{Letter}\p{Mark}\p{Number}\s_-]+/gu, "")
+      .replace(/\s+/g, "-")
+      .replace(/-+/g, "-")
+      .replace(/^-+|-+$/g, "");
+  }
+
+  function uniqueHeadingID(baseID, usedIDs) {
+    let id = baseID;
+    let suffix = 1;
+    while (usedIDs.has(id)) {
+      id = baseID + "-" + suffix;
+      suffix += 1;
+    }
+    return id;
   }
 
   function normalizeLinksAndImages(content, payload) {
@@ -884,11 +926,29 @@
       return;
     }
 
-    const decoded = decodeURIComponent(anchor);
-    const target = document.getElementById(decoded) || document.querySelector("[name='" + CSS.escape(decoded) + "']");
+    const decoded = decodeAnchor(anchor);
+    const slug = slugifyHeadingText(decoded);
+    const target = document.getElementById(decoded) ||
+      (slug && slug !== decoded ? document.getElementById(slug) : null) ||
+      namedAnchorTarget(decoded);
     if (target) {
       target.scrollIntoView({ block: "start", behavior: "smooth" });
     }
+  }
+
+  function decodeAnchor(anchor) {
+    try {
+      return decodeURIComponent(anchor);
+    } catch (_) {
+      return anchor;
+    }
+  }
+
+  function namedAnchorTarget(anchor) {
+    if (!window.CSS || !CSS.escape) {
+      return null;
+    }
+    return document.querySelector("[name='" + CSS.escape(anchor) + "']");
   }
 
   function waitForImages(content) {

--- a/src/SkimDown/Resources/Web/renderer.js
+++ b/src/SkimDown/Resources/Web/renderer.js
@@ -240,7 +240,8 @@
 
   function assignHeadingAnchorIDs(content) {
     const usedIDs = new Set();
-    content.querySelectorAll("[id]").forEach(function (element) {
+    const idScope = content.ownerDocument || document;
+    idScope.querySelectorAll("[id]").forEach(function (element) {
       const id = element.getAttribute("id");
       if (id) {
         usedIDs.add(id);

--- a/src/SkimDownTests/RendererAnchorTests.swift
+++ b/src/SkimDownTests/RendererAnchorTests.swift
@@ -1,0 +1,175 @@
+import WebKit
+import XCTest
+
+final class RendererAnchorTests: XCTestCase {
+    @MainActor
+    func testRendererAssignsHeadingIDsForSectionLinks() async throws {
+        let webView = try await renderMarkdown(
+            """
+            <h2 id="custom-id">Custom Heading</h2>
+
+            ## テスト
+            ## External Links
+            ## External Links
+            """
+        )
+
+        let idsJSON = try await evaluateStringJavaScript(
+            "JSON.stringify(Array.from(document.querySelectorAll('h2')).map(function (heading) { return heading.id; }))",
+            in: webView
+        )
+        let ids = try JSONDecoder().decode([String].self, from: Data(idsJSON.utf8))
+
+        XCTAssertEqual(ids, ["custom-id", "テスト", "external-links", "external-links-1"])
+    }
+
+    @MainActor
+    func testScrollToAnchorFindsDecodedAndSluggedHeadingIDs() async throws {
+        let webView = try await renderMarkdown(
+            """
+            ## テスト
+            ## External Links
+            """
+        )
+
+        let encodedJapaneseTarget = try await evaluateStringJavaScript(
+            """
+            window.__skimdownScrolledTo = null;
+            Array.from(document.querySelectorAll('h2')).forEach(function (heading) {
+              heading.scrollIntoView = function () { window.__skimdownScrolledTo = this.id; };
+            });
+            window.skimdown.scrollToAnchor('%E3%83%86%E3%82%B9%E3%83%88');
+            window.__skimdownScrolledTo;
+            """,
+            in: webView
+        )
+
+        XCTAssertEqual(encodedJapaneseTarget, "テスト")
+
+        let sluggedTarget = try await evaluateStringJavaScript(
+            """
+            window.__skimdownScrolledTo = null;
+            window.skimdown.scrollToAnchor('External%20Links');
+            window.__skimdownScrolledTo;
+            """,
+            in: webView
+        )
+
+        XCTAssertEqual(sluggedTarget, "external-links")
+    }
+
+    @MainActor
+    private func renderMarkdown(_ markdown: String) async throws -> WKWebView {
+        let configuration = WKWebViewConfiguration()
+        let webView = WKWebView(frame: NSRect(x: 0, y: 0, width: 800, height: 1000), configuration: configuration)
+        let navigationDelegate = NavigationFinishedDelegate()
+        let navigationFinished = expectation(description: "renderer HTML loads")
+        navigationDelegate.onDidFinish = {
+            navigationFinished.fulfill()
+        }
+        navigationDelegate.onDidFail = { error in
+            XCTFail("Renderer HTML failed to load: \(error.localizedDescription)")
+            navigationFinished.fulfill()
+        }
+        webView.navigationDelegate = navigationDelegate
+
+        webView.loadHTMLString(try rendererHTML(markdown: markdown), baseURL: Bundle.main.bundleURL)
+        await fulfillment(of: [navigationFinished], timeout: 5)
+        webView.navigationDelegate = nil
+
+        return webView
+    }
+
+    private func rendererHTML(markdown: String) throws -> String {
+        let scripts = try [
+            "vendor/markdown-it/markdown-it.min.js",
+            "vendor/dompurify/purify.min.js",
+            "renderer.js"
+        ].map(readWebResource).joined(separator: "\n")
+
+        let payload: [String: Any] = [
+            "markdown": markdown,
+            "baseURL": Bundle.main.bundleURL.absoluteString,
+            "rootURL": Bundle.main.bundleURL.absoluteString,
+            "localFileScheme": "skimdown-local",
+            "theme": "system",
+            "fontSize": 16,
+            "renderID": 1,
+            "restoreScrollY": 0
+        ]
+
+        return """
+        <!doctype html>
+        <html>
+          <head>
+            <meta charset="utf-8">
+          </head>
+          <body>
+            <main id="content"></main>
+            <script>\(scripts)</script>
+            <script>window.skimdown.render(\(try jsonObject(payload)));</script>
+          </body>
+        </html>
+        """
+    }
+
+    private func readWebResource(_ relativePath: String) throws -> String {
+        guard let url = Bundle.main.resourceURL?.appendingPathComponent("Web").appendingPathComponent(relativePath) else {
+            throw RendererAnchorTestError.missingResource(relativePath)
+        }
+
+        return try String(contentsOf: url, encoding: .utf8)
+    }
+
+    private func jsonObject(_ object: Any) throws -> String {
+        let data = try JSONSerialization.data(withJSONObject: object)
+        guard let string = String(data: data, encoding: .utf8) else {
+            throw RendererAnchorTestError.invalidJSON
+        }
+        return string.replacingOccurrences(of: "</", with: "<\\/")
+    }
+
+    @MainActor
+    private func evaluateStringJavaScript(_ script: String, in webView: WKWebView) async throws -> String {
+        try await withCheckedThrowingContinuation { continuation in
+            webView.evaluateJavaScript(script) { value, error in
+                if let error {
+                    continuation.resume(throwing: RendererAnchorTestError.scriptEvaluationFailed(error.localizedDescription))
+                    return
+                }
+
+                guard let string = value as? String else {
+                    continuation.resume(throwing: RendererAnchorTestError.invalidScriptResult)
+                    return
+                }
+
+                continuation.resume(returning: string)
+            }
+        }
+    }
+}
+
+private enum RendererAnchorTestError: Error {
+    case missingResource(String)
+    case invalidJSON
+    case invalidScriptResult
+    case scriptEvaluationFailed(String)
+}
+
+@MainActor
+private final class NavigationFinishedDelegate: NSObject, WKNavigationDelegate {
+    var onDidFinish: (() -> Void)?
+    var onDidFail: ((Error) -> Void)?
+
+    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        onDidFinish?()
+    }
+
+    func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
+        onDidFail?(error)
+    }
+
+    func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
+        onDidFail?(error)
+    }
+}

--- a/src/SkimDownTests/RendererAnchorTests.swift
+++ b/src/SkimDownTests/RendererAnchorTests.swift
@@ -1,5 +1,6 @@
 import WebKit
 import XCTest
+@testable import SkimDown
 
 final class RendererAnchorTests: XCTestCase {
     @MainActor
@@ -8,6 +9,7 @@ final class RendererAnchorTests: XCTestCase {
             """
             <h2 id="custom-id">Custom Heading</h2>
 
+            ## Content
             ## テスト
             ## External Links
             ## External Links
@@ -20,7 +22,7 @@ final class RendererAnchorTests: XCTestCase {
         )
         let ids = try JSONDecoder().decode([String].self, from: Data(idsJSON.utf8))
 
-        XCTAssertEqual(ids, ["custom-id", "テスト", "external-links", "external-links-1"])
+        XCTAssertEqual(ids, ["custom-id", "content-1", "テスト", "external-links", "external-links-1"])
     }
 
     @MainActor
@@ -91,7 +93,7 @@ final class RendererAnchorTests: XCTestCase {
             "markdown": markdown,
             "baseURL": Bundle.main.bundleURL.absoluteString,
             "rootURL": Bundle.main.bundleURL.absoluteString,
-            "localFileScheme": "skimdown-local",
+            "localFileScheme": LocalFileSchemeHandler.scheme,
             "theme": "system",
             "fontSize": 16,
             "renderID": 1,


### PR DESCRIPTION
## Summary
- Assign stable IDs to rendered Markdown headings so section anchors can resolve their targets
- Preserve existing heading IDs, support Japanese anchors, and disambiguate duplicate headings
- Add WebView renderer tests for heading ID generation and decoded/slugged anchor lookup

## Tests
- `make test`

Fixes #30