### PR TITLE
Implement Mermaid expanded pane

### DIFF
--- a/src/SkimDown/Resources/Web/renderer.js
+++ b/src/SkimDown/Resources/Web/renderer.js
@@ -6,6 +6,8 @@
   let tableResizeHandler = null;
   let mermaidResizeObserver = null;
   let mermaidResizeHandler = null;
+  let activeMermaidModal = null;
+  let mermaidModalSequence = 0;
   const IMAGE_READY_TIMEOUT_MS = 3000;
   const CODE_COPY_FEEDBACK_RESET_MS = 1500;
   // Matches standalone #RGB, #RGBA, #RRGGBB, and #RRGGBBAA color codes.
@@ -102,6 +104,7 @@
     }
     document.documentElement.dataset.theme = payload.theme || "system";
     document.documentElement.style.setProperty("--skimdown-font-size", String(payload.fontSize || 16) + "px");
+    closeActiveMermaidModal();
 
     const content = document.getElementById("content");
     const dirtyHtml = renderer().render(payload.markdown || "");
@@ -506,7 +509,7 @@
       diagram.textContent = source;
       viewport.appendChild(diagram);
       wrapper.appendChild(viewport);
-      wrapper.appendChild(buildMermaidToolbar(viewport));
+      wrapper.appendChild(buildMermaidToolbar(wrapper, viewport));
       code.parentElement.replaceWith(wrapper);
 
       initMermaidZoomPan(wrapper, viewport);
@@ -539,6 +542,7 @@
           // body font-size. The card uses overflow: hidden, and drag-to-pan handles
           // diagrams that overflow the card (see initMermaidOverflowWatcher).
           initMermaidOverflowWatcher(entry.wrapper, svg);
+          enableMermaidExpandButton(entry.wrapper);
         });
       });
     return [task];
@@ -607,7 +611,7 @@
     }
   }
 
-  function buildMermaidToolbar(viewport) {
+  function buildMermaidToolbar(container, viewport) {
     var toolbar = document.createElement("div");
     toolbar.className = "mermaid-toolbar";
 
@@ -629,48 +633,452 @@
     zoomReset.textContent = "Reset";
     zoomReset.setAttribute("aria-label", "Reset zoom");
 
+    var expand = document.createElement("button");
+    expand.type = "button";
+    expand.className = "mermaid-zoom-btn mermaid-expand";
+    expand.textContent = "Expand";
+    expand.setAttribute("aria-label", "Open Mermaid diagram in expanded pane");
+    expand.disabled = true;
+
     zoomIn.addEventListener("click", function () {
-      applyMermaidZoom(viewport, 0.25);
+      applyMermaidZoom(container, viewport, 0.25);
     });
     zoomOut.addEventListener("click", function () {
-      applyMermaidZoom(viewport, -0.25);
+      applyMermaidZoom(container, viewport, -0.25);
     });
     zoomReset.addEventListener("click", function () {
-      resetMermaidZoom(viewport);
+      resetMermaidZoom(container, viewport);
+    });
+    expand.addEventListener("click", function () {
+      openMermaidModal(container, expand);
     });
 
     toolbar.appendChild(zoomOut);
     toolbar.appendChild(zoomReset);
     toolbar.appendChild(zoomIn);
+    toolbar.appendChild(expand);
     return toolbar;
+  }
+
+  function enableMermaidExpandButton(container) {
+    var button = container.querySelector(".mermaid-expand");
+    if (button) {
+      button.disabled = false;
+    }
+  }
+
+  function openMermaidModal(container, openerElement) {
+    var sourceSVG = container.querySelector("svg");
+    if (!sourceSVG) {
+      return;
+    }
+
+    closeActiveMermaidModal();
+
+    var activeElement = document.activeElement;
+    var opener = openerElement && openerElement.focus
+      ? openerElement
+      : activeElement && activeElement !== document.body && activeElement.focus
+      ? document.activeElement
+      : container;
+    var modalID = "skimdown-mermaid-modal-" + (++mermaidModalSequence);
+    var modal = document.createElement("div");
+    modal.className = "mermaid-modal";
+    modal.tabIndex = -1;
+    modal.setAttribute("role", "dialog");
+    modal.setAttribute("aria-modal", "true");
+    modal.setAttribute("aria-labelledby", modalID + "-title");
+
+    var panel = document.createElement("div");
+    panel.className = "mermaid-modal-panel";
+
+    var header = document.createElement("div");
+    header.className = "mermaid-modal-header";
+
+    var title = document.createElement("div");
+    title.id = modalID + "-title";
+    title.className = "mermaid-modal-title";
+    title.textContent = "Mermaid diagram";
+
+    var controls = document.createElement("div");
+    controls.className = "mermaid-modal-controls";
+
+    var zoomOut = buildMermaidModalButton("\u2212", "Zoom out", "mermaid-modal-zoom-out");
+    var zoomReset = buildMermaidModalButton("Reset", "Reset zoom", "mermaid-modal-zoom-reset");
+    var zoomIn = buildMermaidModalButton("+", "Zoom in", "mermaid-modal-zoom-in");
+    var closeButton = buildMermaidModalButton("Close", "Close expanded Mermaid diagram", "mermaid-modal-close");
+
+    var frame = document.createElement("div");
+    frame.className = "mermaid-modal-frame";
+
+    var viewport = document.createElement("div");
+    viewport.className = "mermaid-modal-viewport";
+    var modalSVG = cloneMermaidSVGForModal(sourceSVG);
+    viewport.dataset.baseWidth = String(modalSVG.width);
+    viewport.dataset.baseHeight = String(modalSVG.height);
+    viewport.appendChild(modalSVG.svg);
+    frame.appendChild(viewport);
+
+    zoomOut.addEventListener("click", function () {
+      applyMermaidZoom(modal, viewport, -0.25);
+      resizeHandler();
+    });
+    zoomReset.addEventListener("click", function () {
+      refreshMermaidModalBaseline(frame, viewport);
+      resetMermaidZoom(modal, viewport);
+      resizeHandler();
+    });
+    zoomIn.addEventListener("click", function () {
+      applyMermaidZoom(modal, viewport, 0.25);
+      resizeHandler();
+    });
+    closeButton.addEventListener("click", closeModal);
+
+    controls.appendChild(zoomOut);
+    controls.appendChild(zoomReset);
+    controls.appendChild(zoomIn);
+    controls.appendChild(closeButton);
+    header.appendChild(title);
+    header.appendChild(controls);
+    panel.appendChild(header);
+    panel.appendChild(frame);
+    modal.appendChild(panel);
+
+    var resizeHandler = function () {
+      updateMermaidModalOverflow(modal, frame, viewport);
+    };
+    var backdropMouseDown = false;
+
+    function closeModal() {
+      if (!activeMermaidModal || activeMermaidModal.element !== modal) {
+        return;
+      }
+      endMermaidDrag();
+      window.removeEventListener("resize", resizeHandler);
+      modal.remove();
+      document.documentElement.classList.remove("skimdown-mermaid-modal-open");
+      document.body.classList.remove("skimdown-mermaid-modal-open");
+      activeMermaidModal = null;
+      restoreMermaidModalFocus(opener, container);
+    }
+
+    modal.addEventListener("mousedown", function (event) {
+      backdropMouseDown = event.target === modal;
+    });
+    modal.addEventListener("click", function (event) {
+      if (event.target === modal && backdropMouseDown) {
+        closeModal();
+      }
+      backdropMouseDown = false;
+    });
+    modal.addEventListener("keydown", function (event) {
+      handleMermaidModalKeydown(event, modal, closeModal);
+    });
+
+    activeMermaidModal = { element: modal, close: closeModal };
+    document.documentElement.classList.add("skimdown-mermaid-modal-open");
+    document.body.classList.add("skimdown-mermaid-modal-open");
+    document.body.appendChild(modal);
+
+    initMermaidZoomPan(modal, viewport, {
+      wheelTarget: frame,
+      preventPlainWheel: true,
+      alwaysAllowPan: true,
+      overflowClass: "mermaid-modal-overflowing"
+    });
+    window.addEventListener("resize", resizeHandler);
+    initializeMermaidModalZoom(modal, frame, viewport);
+    updateMermaidModalOverflow(modal, frame, viewport);
+    window.requestAnimationFrame(function () {
+      if (!activeMermaidModal || activeMermaidModal.element !== modal) {
+        return;
+      }
+      updateMermaidModalOverflow(modal, frame, viewport);
+      closeButton.focus();
+    });
+  }
+
+  function closeActiveMermaidModal() {
+    if (activeMermaidModal) {
+      activeMermaidModal.close();
+    }
+  }
+
+  function restoreMermaidModalFocus(opener, container) {
+    if (opener && opener.focus && document.contains(opener)) {
+      opener.focus();
+      if (document.activeElement === opener) {
+        return;
+      }
+    }
+    if (container && container.focus && document.contains(container)) {
+      container.focus();
+    }
+  }
+
+  function buildMermaidModalButton(text, ariaLabel, className) {
+    var button = document.createElement("button");
+    button.type = "button";
+    button.className = "mermaid-modal-button " + className;
+    button.textContent = text;
+    button.setAttribute("aria-label", ariaLabel);
+    return button;
+  }
+
+  function handleMermaidModalKeydown(event, modal, closeModal) {
+    if (event.key === "Escape") {
+      event.preventDefault();
+      event.stopPropagation();
+      closeModal();
+      return;
+    }
+
+    if (event.key !== "Tab") {
+      return;
+    }
+
+    var focusable = mermaidModalFocusableElements(modal);
+    if (focusable.length === 0) {
+      event.preventDefault();
+      modal.focus();
+      return;
+    }
+
+    var first = focusable[0];
+    var last = focusable[focusable.length - 1];
+    if (event.shiftKey && document.activeElement === first) {
+      event.preventDefault();
+      last.focus();
+    } else if (!event.shiftKey && document.activeElement === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  }
+
+  function mermaidModalFocusableElements(modal) {
+    return Array.from(modal.querySelectorAll([
+      "button:not([disabled])",
+      "[href]",
+      "input:not([disabled])",
+      "select:not([disabled])",
+      "textarea:not([disabled])",
+      "[tabindex]:not([tabindex='-1'])"
+    ].join(","))).filter(function (element) {
+      return element.getAttribute("aria-hidden") !== "true";
+    });
+  }
+
+  function cloneMermaidSVGForModal(sourceSVG) {
+    var clone = sourceSVG.cloneNode(true);
+    var baseSize = mermaidSVGBaseSize(sourceSVG);
+    var suffix = "skimdown-modal-svg-" + (++mermaidModalSequence);
+    var elements = [clone].concat(Array.from(clone.querySelectorAll("*")));
+    var idMap = new Map();
+
+    elements.forEach(function (element) {
+      var id = element.getAttribute("id");
+      if (!id) {
+        return;
+      }
+      var newID = id + "-" + suffix;
+      idMap.set(id, newID);
+      element.setAttribute("id", newID);
+    });
+
+    if (idMap.size > 0) {
+      elements.forEach(function (element) {
+        Array.from(element.attributes || []).forEach(function (attribute) {
+          var remapped = remapMermaidSVGAttributeValue(attribute.name, attribute.value, idMap);
+          if (remapped !== attribute.value) {
+            element.setAttribute(attribute.name, remapped);
+          }
+        });
+        if (element.tagName && element.tagName.toLowerCase() === "style") {
+          element.textContent = remapMermaidSVGReferences(element.textContent || "", idMap);
+        }
+      });
+    }
+
+    clone.classList.add("mermaid-modal-svg");
+    normalizeMermaidModalSVG(clone, baseSize);
+    return { svg: clone, width: baseSize.width, height: baseSize.height };
+  }
+
+  function mermaidSVGBaseSize(svg) {
+    var viewBoxSize = mermaidSVGViewBoxSize(svg);
+    if (viewBoxSize) {
+      return viewBoxSize;
+    }
+
+    var attrWidth = parseSVGLength(svg.getAttribute("width"));
+    var attrHeight = parseSVGLength(svg.getAttribute("height"));
+    if (attrWidth && attrHeight) {
+      return { width: attrWidth, height: attrHeight };
+    }
+
+    try {
+      var bbox = svg.getBBox();
+      if (bbox && bbox.width > 0 && bbox.height > 0) {
+        return { width: bbox.width, height: bbox.height };
+      }
+    } catch (_) {}
+
+    var rect = svg.getBoundingClientRect();
+    if (rect.width > 0 && rect.height > 0) {
+      return { width: rect.width, height: rect.height };
+    }
+
+    return { width: 300, height: 150 };
+  }
+
+  function mermaidSVGViewBoxSize(svg) {
+    var viewBox = svg.getAttribute("viewBox");
+    if (!viewBox) {
+      return null;
+    }
+    var values = viewBox.trim().split(/[\s,]+/).map(Number);
+    if (values.length !== 4 || values.some(function (value) { return !Number.isFinite(value); })) {
+      return null;
+    }
+    var width = values[2];
+    var height = values[3];
+    if (width <= 0 || height <= 0) {
+      return null;
+    }
+    return { width: width, height: height };
+  }
+
+  function parseSVGLength(value) {
+    if (!value) {
+      return null;
+    }
+    var trimmed = String(value).trim();
+    if (trimmed.endsWith("%")) {
+      return null;
+    }
+    var number = parseFloat(trimmed);
+    return Number.isFinite(number) && number > 0 ? number : null;
+  }
+
+  function normalizeMermaidModalSVG(svg, baseSize) {
+    var width = Math.max(1, Math.round(baseSize.width * 100) / 100);
+    var height = Math.max(1, Math.round(baseSize.height * 100) / 100);
+
+    svg.setAttribute("width", String(width));
+    svg.setAttribute("height", String(height));
+    svg.style.width = width + "px";
+    svg.style.height = height + "px";
+    svg.style.maxWidth = "none";
+    svg.style.maxHeight = "none";
+  }
+
+  function remapMermaidSVGAttributeValue(name, value, idMap) {
+    if (name === "aria-labelledby" || name === "aria-describedby") {
+      return String(value).split(/\s+/).map(function (id) {
+        return idMap.get(id) || id;
+      }).join(" ");
+    }
+    return remapMermaidSVGReferences(value, idMap);
+  }
+
+  function remapMermaidSVGReferences(value, idMap) {
+    var next = value;
+    idMap.forEach(function (newID, oldID) {
+      var escapedID = escapeRegExp(oldID);
+      next = next.replace(new RegExp("url\\(\\s*#" + escapedID + "\\s*\\)", "g"), "url(#" + newID + ")");
+      next = next.replace(new RegExp("#" + escapedID + "(?![A-Za-z0-9_-])", "g"), "#" + newID);
+    });
+    return next;
+  }
+
+  function updateMermaidModalOverflow(modal, frame, viewport) {
+    var svg = viewport.querySelector("svg");
+    if (!svg) {
+      modal.classList.remove("mermaid-modal-overflowing");
+      return;
+    }
+    var svgRect = svg.getBoundingClientRect();
+    var frameRect = frame.getBoundingClientRect();
+    modal.classList.toggle(
+      "mermaid-modal-overflowing",
+      svgRect.width > frameRect.width + 1 || svgRect.height > frameRect.height + 1
+    );
+  }
+
+  function initializeMermaidModalZoom(modal, frame, viewport) {
+    refreshMermaidModalBaseline(frame, viewport);
+    resetMermaidZoom(modal, viewport);
+  }
+
+  function refreshMermaidModalBaseline(frame, viewport) {
+    var baseline = mermaidModalInitialZoom(frame, viewport);
+    viewport.dataset.zoomBaseline = String(baseline);
+    return baseline;
+  }
+
+  function mermaidModalInitialZoom(frame, viewport) {
+    var baseWidth = parseFloat(viewport.dataset.baseWidth) || 0;
+    var baseHeight = parseFloat(viewport.dataset.baseHeight) || 0;
+    if (baseWidth <= 0 || baseHeight <= 0) {
+      return 1;
+    }
+
+    var available = mermaidModalAvailableSize(frame);
+    if (available.width <= 0 || available.height <= 0) {
+      return 1;
+    }
+
+    var contain = Math.min(available.width / baseWidth, available.height / baseHeight);
+    if (!Number.isFinite(contain) || contain <= 0) {
+      return 1;
+    }
+    return Math.max(0.01, Math.floor(Math.min(contain, 3) * 100) / 100);
+  }
+
+  function mermaidModalAvailableSize(frame) {
+    var style = window.getComputedStyle(frame);
+    var horizontalPadding = parseFloat(style.paddingLeft) + parseFloat(style.paddingRight);
+    var verticalPadding = parseFloat(style.paddingTop) + parseFloat(style.paddingBottom);
+    return {
+      width: Math.max(0, frame.clientWidth - (Number.isFinite(horizontalPadding) ? horizontalPadding : 0)),
+      height: Math.max(0, frame.clientHeight - (Number.isFinite(verticalPadding) ? verticalPadding : 0))
+    };
   }
 
   function updateViewportTransform(viewport, zoom, px, py) {
     viewport.style.transform = "translate(" + px + "px, " + py + "px) scale(" + zoom + ")";
   }
 
-  function applyMermaidZoom(viewport, delta) {
+  function applyMermaidZoom(container, viewport, delta) {
     var current = parseFloat(viewport.dataset.zoom) || 1;
-    var next = Math.round(Math.min(Math.max(current + delta, 0.25), 4) * 100) / 100;
-    if (Math.abs(next - 1) < 0.05) { next = 1; }
-    if (next === 1) {
-      resetMermaidZoom(viewport);
+    var baseline = parseFloat(viewport.dataset.zoomBaseline) || 1;
+    var minZoom = Math.min(0.25, baseline);
+    var next = Math.round(Math.min(Math.max(current + delta, minZoom), 4) * 100) / 100;
+    if (Math.abs(next - baseline) < 0.05) { next = baseline; }
+    if (next === baseline) {
+      resetMermaidZoom(container, viewport);
       return;
     }
     viewport.dataset.zoom = String(next);
     updateViewportTransform(viewport, next, parseFloat(viewport.dataset.panX) || 0, parseFloat(viewport.dataset.panY) || 0);
-    // Only flag as "zoomed" when above 1x — drag-to-pan is gated on zoom > 1, so the
-    // grab cursor should not appear for zoom-out states (0.25x–0.95x) where panning
-    // is intentionally disabled.
-    viewport.closest(".mermaid-container").classList.toggle("mermaid-zoomed", next > 1);
+    if (container) {
+      container.classList.toggle("mermaid-zoomed", next > baseline);
+    }
   }
 
-  function resetMermaidZoom(viewport) {
-    viewport.dataset.zoom = "1";
+  function resetMermaidZoom(container, viewport) {
+    var baseline = parseFloat(viewport.dataset.zoomBaseline) || 1;
+    viewport.dataset.zoom = String(baseline);
     viewport.dataset.panX = "0";
     viewport.dataset.panY = "0";
-    viewport.style.transform = "";
-    viewport.closest(".mermaid-container").classList.remove("mermaid-zoomed");
+    if (baseline === 1) {
+      viewport.style.transform = "";
+    } else {
+      updateViewportTransform(viewport, baseline, 0, 0);
+    }
+    if (container) {
+      container.classList.remove("mermaid-zoomed");
+    }
   }
 
   var activeDragViewport = null;
@@ -702,19 +1110,34 @@
   document.addEventListener("mouseleave", endMermaidDrag);
   window.addEventListener("blur", endMermaidDrag);
 
-  function initMermaidZoomPan(container, viewport) {
-    container.addEventListener("wheel", function (e) {
-      if (!e.ctrlKey && !e.metaKey) { return; }
+  function initMermaidZoomPan(container, viewport, options) {
+    options = options || {};
+    var wheelTarget = options.wheelTarget || container;
+    var overflowClass = options.overflowClass || "mermaid-overflowing";
+    var preventPlainWheel = options.preventPlainWheel === true;
+    var alwaysAllowPan = options.alwaysAllowPan === true;
+
+    wheelTarget.addEventListener("wheel", function (e) {
+      if (!e.ctrlKey && !e.metaKey) {
+        if (preventPlainWheel) {
+          e.preventDefault();
+          e.stopPropagation();
+        }
+        return;
+      }
       e.preventDefault();
+      if (preventPlainWheel) {
+        e.stopPropagation();
+      }
       var delta = e.deltaY > 0 ? -0.1 : 0.1;
-      applyMermaidZoom(viewport, delta);
+      applyMermaidZoom(container, viewport, delta);
     }, { passive: false });
 
     viewport.addEventListener("mousedown", function (e) {
       if (e.button !== 0) { return; }
       var zoom = parseFloat(viewport.dataset.zoom) || 1;
       // Allow drag-to-pan when zoomed in OR when the diagram overflows the card.
-      if (zoom <= 1 && !container.classList.contains("mermaid-overflowing")) { return; }
+      if (!alwaysAllowPan && zoom <= 1 && !container.classList.contains(overflowClass)) { return; }
       e.preventDefault();
       activeDragViewport = viewport;
       viewport.classList.add("mermaid-dragging");

--- a/src/SkimDown/Resources/Web/renderer.js
+++ b/src/SkimDown/Resources/Web/renderer.js
@@ -860,7 +860,10 @@
 
     var first = focusable[0];
     var last = focusable[focusable.length - 1];
-    if (event.shiftKey && document.activeElement === first) {
+    if (document.activeElement === modal) {
+      event.preventDefault();
+      (event.shiftKey ? last : first).focus();
+    } else if (event.shiftKey && document.activeElement === first) {
       event.preventDefault();
       last.focus();
     } else if (!event.shiftKey && document.activeElement === last) {

--- a/src/SkimDown/Resources/Web/renderer.js
+++ b/src/SkimDown/Resources/Web/renderer.js
@@ -679,7 +679,7 @@
     var opener = openerElement && openerElement.focus
       ? openerElement
       : activeElement && activeElement !== document.body && activeElement.focus
-      ? document.activeElement
+      ? activeElement
       : container;
     var modalID = "skimdown-mermaid-modal-" + (++mermaidModalSequence);
     var modal = document.createElement("div");

--- a/src/SkimDown/Resources/Web/renderer.js
+++ b/src/SkimDown/Resources/Web/renderer.js
@@ -805,15 +805,29 @@
   }
 
   function restoreMermaidModalFocus(opener, container) {
-    if (opener && opener.focus && document.contains(opener)) {
+    if (isRestorableMermaidFocusTarget(opener)) {
       opener.focus();
       if (document.activeElement === opener) {
         return;
       }
     }
-    if (container && container.focus && document.contains(container)) {
+    if (isRestorableMermaidFocusTarget(container)) {
       container.focus();
     }
+  }
+
+  function isRestorableMermaidFocusTarget(element) {
+    if (!element || typeof element.focus !== "function" || !document.contains(element)) {
+      return false;
+    }
+    if (element.disabled || element.getAttribute("aria-disabled") === "true") {
+      return false;
+    }
+    var style = window.getComputedStyle(element);
+    if (!style || style.display === "none" || style.visibility === "hidden") {
+      return false;
+    }
+    return element.getClientRects().length > 0;
   }
 
   function buildMermaidModalButton(text, ariaLabel, className) {

--- a/src/SkimDown/Resources/Web/skimdown.css
+++ b/src/SkimDown/Resources/Web/skimdown.css
@@ -458,7 +458,12 @@ tr:nth-child(even) td {
   backdrop-filter: blur(10px);
 }
 
-.mermaid-modal:focus {
+.mermaid-modal:focus-visible {
+  outline: 2px solid var(--skimdown-accent);
+  outline-offset: -4px;
+}
+
+.mermaid-modal:focus:not(:focus-visible) {
   outline: none;
 }
 

--- a/src/SkimDown/Resources/Web/skimdown.css
+++ b/src/SkimDown/Resources/Web/skimdown.css
@@ -10,6 +10,7 @@
   --skimdown-accent: #0a66d6;
   --skimdown-mark: #fff8c5;
   --skimdown-current-mark: #ffd33d;
+  --skimdown-z-modal: 1000;
 }
 
 :root[data-theme="dark"],
@@ -68,6 +69,11 @@ body {
 
 body.skimdown-restoring #content {
   visibility: hidden;
+}
+
+html.skimdown-mermaid-modal-open,
+body.skimdown-mermaid-modal-open {
+  overflow: hidden;
 }
 
 #content > :first-child {
@@ -421,10 +427,141 @@ tr:nth-child(even) td {
   background: var(--skimdown-border);
 }
 
+.mermaid-zoom-btn:disabled {
+  opacity: 0.45;
+  cursor: default;
+}
+
+.mermaid-zoom-btn:disabled:hover {
+  background: var(--skimdown-surface);
+}
+
 .mermaid-zoom-btn.mermaid-zoom-reset {
   width: auto;
   padding: 0 8px;
   font-size: 11px;
+}
+
+.mermaid-zoom-btn.mermaid-expand {
+  width: auto;
+  padding: 0 8px;
+  font-size: 11px;
+}
+
+.mermaid-modal {
+  position: fixed;
+  inset: 0;
+  z-index: var(--skimdown-z-modal);
+  display: flex;
+  padding: clamp(14px, 3vw, 32px);
+  background: color-mix(in srgb, var(--skimdown-bg) 62%, transparent);
+  backdrop-filter: blur(10px);
+}
+
+.mermaid-modal:focus {
+  outline: none;
+}
+
+.mermaid-modal-panel {
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+  border: 1px solid var(--skimdown-border);
+  border-radius: 16px;
+  background: var(--skimdown-bg);
+  box-shadow: 0 24px 70px rgba(0, 0, 0, 0.28);
+}
+
+.mermaid-modal-header {
+  display: flex;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--skimdown-border);
+  background: color-mix(in srgb, var(--skimdown-surface) 82%, var(--skimdown-bg));
+}
+
+.mermaid-modal-title {
+  overflow: hidden;
+  color: var(--skimdown-fg);
+  font-weight: 600;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.mermaid-modal-controls {
+  display: flex;
+  flex: 0 0 auto;
+  gap: 6px;
+  align-items: center;
+}
+
+.mermaid-modal-button {
+  min-width: 32px;
+  height: 30px;
+  border: 1px solid var(--skimdown-border);
+  border-radius: 7px;
+  padding: 0 9px;
+  background: var(--skimdown-surface);
+  color: var(--skimdown-fg);
+  font: inherit;
+  font-size: 12px;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.mermaid-modal-button:hover {
+  background: var(--skimdown-border);
+}
+
+.mermaid-modal-button:focus-visible {
+  outline: 2px solid var(--skimdown-accent);
+  outline-offset: 2px;
+}
+
+.mermaid-modal-frame {
+  display: flex;
+  flex: 1 1 auto;
+  align-items: center;
+  justify-content: center;
+  min-height: 0;
+  overflow: hidden;
+  padding: clamp(16px, 3vw, 32px);
+  background: var(--skimdown-surface);
+}
+
+.mermaid-modal-viewport {
+  flex: 0 0 auto;
+  transform-origin: center center;
+  transition: transform 0.1s ease;
+  will-change: transform;
+  cursor: grab;
+}
+
+.mermaid-modal-viewport.mermaid-dragging {
+  transition: none;
+}
+
+.mermaid-modal-overflowing .mermaid-modal-viewport,
+.mermaid-zoomed .mermaid-modal-viewport {
+  cursor: grab;
+}
+
+.mermaid-modal svg {
+  display: block;
+  max-width: none;
+  margin: 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .mermaid-modal-viewport {
+    transition: none;
+  }
 }
 
 .skimdown-search-match {

--- a/src/SkimDownTests/RendererAnchorTests.swift
+++ b/src/SkimDownTests/RendererAnchorTests.swift
@@ -273,6 +273,12 @@ final class RendererAnchorTests: XCTestCase {
               modal.dispatchEvent(new MouseEvent('click', { bubbles: true }));
               var stayedOpenAfterDragReleaseOnBackdrop = document.querySelector('.mermaid-modal') !== null;
 
+              var openerFocusAttemptedAfterHidden = false;
+              var originalExpandFocus = expand.focus.bind(expand);
+              expand.focus = function () {
+                openerFocusAttemptedAfterHidden = true;
+                originalExpandFocus();
+              };
               expand.style.visibility = 'hidden';
               modal.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
 
@@ -300,6 +306,7 @@ final class RendererAnchorTests: XCTestCase {
                 modalExistsAfterClose: document.querySelector('.mermaid-modal') !== null,
                 bodyLockedAfterClose: document.body.classList.contains('skimdown-mermaid-modal-open'),
                 htmlLockedAfterClose: document.documentElement.classList.contains('skimdown-mermaid-modal-open'),
+                openerFocusAttemptedAfterHidden: openerFocusAttemptedAfterHidden,
                 focusRestoredToContainer: document.activeElement === document.querySelector('.mermaid-container'),
                 originalMarkerID: originalMarkerID,
                 modalMarkerID: modalMarkerID,
@@ -339,6 +346,7 @@ final class RendererAnchorTests: XCTestCase {
         XCTAssertFalse(result.modalExistsAfterClose)
         XCTAssertFalse(result.bodyLockedAfterClose)
         XCTAssertFalse(result.htmlLockedAfterClose)
+        XCTAssertFalse(result.openerFocusAttemptedAfterHidden)
         XCTAssertTrue(result.focusRestoredToContainer)
         XCTAssertNotEqual(result.originalMarkerID, result.modalMarkerID)
         XCTAssertEqual(result.modalMarkerEnd, "url(#\(result.modalMarkerID))")
@@ -731,6 +739,7 @@ private struct MermaidExpandPaneResult: Decodable {
     let modalExistsAfterClose: Bool
     let bodyLockedAfterClose: Bool
     let htmlLockedAfterClose: Bool
+    let openerFocusAttemptedAfterHidden: Bool
     let focusRestoredToContainer: Bool
     let originalMarkerID: String
     let modalMarkerID: String

--- a/src/SkimDownTests/RendererAnchorTests.swift
+++ b/src/SkimDownTests/RendererAnchorTests.swift
@@ -252,6 +252,14 @@ final class RendererAnchorTests: XCTestCase {
               var htmlLockedAfterOpen = document.documentElement.classList.contains('skimdown-mermaid-modal-open');
               var baselineZoom = Number(viewport.dataset.zoomBaseline);
               var initialZoom = Number(viewport.dataset.zoom);
+              var firstControl = modal.querySelector('.mermaid-modal-zoom-out');
+              var lastControl = modal.querySelector('.mermaid-modal-close');
+              modal.focus();
+              modal.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', bubbles: true, cancelable: true }));
+              var tabFromModalFocusesFirstControl = document.activeElement === firstControl;
+              modal.focus();
+              modal.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', shiftKey: true, bubbles: true, cancelable: true }));
+              var shiftTabFromModalFocusesLastControl = document.activeElement === lastControl;
 
               modal.querySelector('.mermaid-modal-zoom-in').click();
               var zoomAfterZoomIn = Number(viewport.dataset.zoom);
@@ -293,6 +301,8 @@ final class RendererAnchorTests: XCTestCase {
                 modalSVGStyleMaxWidth: modalSVG.style.maxWidth,
                 baselineZoom: baselineZoom,
                 initialZoom: initialZoom,
+                tabFromModalFocusesFirstControl: tabFromModalFocusesFirstControl,
+                shiftTabFromModalFocusesLastControl: shiftTabFromModalFocusesLastControl,
                 zoomAfterZoomIn: zoomAfterZoomIn,
                 zoomAfterResizeEvent: zoomAfterResizeEvent,
                 baselineAfterResizeEvent: baselineAfterResizeEvent,
@@ -328,6 +338,8 @@ final class RendererAnchorTests: XCTestCase {
         XCTAssertEqual(result.modalSVGStyleMaxWidth, "none")
         XCTAssertLessThan(result.baselineZoom, 1)
         XCTAssertEqual(result.initialZoom, result.baselineZoom, accuracy: 0.001)
+        XCTAssertTrue(result.tabFromModalFocusesFirstControl)
+        XCTAssertTrue(result.shiftTabFromModalFocusesLastControl)
         XCTAssertGreaterThan(result.zoomAfterZoomIn, result.baselineZoom)
         XCTAssertTrue(result.transformAfterZoom.contains("scale("))
         XCTAssertEqual(result.zoomAfterResizeEvent, result.zoomAfterZoomIn, accuracy: 0.001)
@@ -726,6 +738,8 @@ private struct MermaidExpandPaneResult: Decodable {
     let modalSVGStyleMaxWidth: String
     let baselineZoom: Double
     let initialZoom: Double
+    let tabFromModalFocusesFirstControl: Bool
+    let shiftTabFromModalFocusesLastControl: Bool
     let zoomAfterZoomIn: Double
     let zoomAfterResizeEvent: Double
     let baselineAfterResizeEvent: Double

--- a/src/SkimDownTests/RendererAnchorTests.swift
+++ b/src/SkimDownTests/RendererAnchorTests.swift
@@ -204,6 +204,147 @@ final class RendererAnchorTests: XCTestCase {
     }
 
     @MainActor
+    func testMermaidExpandPaneOpensZoomsAndCloses() async throws {
+        let webView = try await renderMarkdown(
+            """
+            ```mermaid
+            graph LR
+                A[Start] --> B[Middle] --> C[End]
+            ```
+            """,
+            additionalScripts: [Self.mermaidStubScript],
+            additionalStyles: [Self.mermaidModalTestStyle]
+        )
+        try await waitForJavaScriptCondition(
+            "document.querySelector('.mermaid-expand:not([disabled])') !== null",
+            in: webView
+        )
+
+        try await evaluateStringJavaScript(
+            """
+            (function () {
+              var expand = document.querySelector('.mermaid-expand');
+              document.body.tabIndex = -1;
+              document.body.focus();
+              expand.click();
+              return "opened";
+            })();
+            """,
+            in: webView
+        )
+        try await waitForJavaScriptCondition(
+            "document.querySelector('.mermaid-modal-viewport') && document.querySelector('.mermaid-modal-viewport').dataset.zoomBaseline",
+            in: webView
+        )
+
+        let resultJSON = try await evaluateStringJavaScript(
+            """
+            (function () {
+              var expand = document.querySelector('.mermaid-expand');
+              var modal = document.querySelector('.mermaid-modal');
+              var viewport = modal.querySelector('.mermaid-modal-viewport');
+              var frame = modal.querySelector('.mermaid-modal-frame');
+              var modalSVG = modal.querySelector('svg');
+              var originalMarkerID = document.querySelector('.mermaid-container svg marker').id;
+              var modalMarkerID = modalSVG.querySelector('marker').id;
+              var modalMarkerEnd = modalSVG.querySelector('path[marker-end]').getAttribute('marker-end');
+              var bodyLockedAfterOpen = document.body.classList.contains('skimdown-mermaid-modal-open');
+              var htmlLockedAfterOpen = document.documentElement.classList.contains('skimdown-mermaid-modal-open');
+              var baselineZoom = Number(viewport.dataset.zoomBaseline);
+              var initialZoom = Number(viewport.dataset.zoom);
+
+              modal.querySelector('.mermaid-modal-zoom-in').click();
+              var zoomAfterZoomIn = Number(viewport.dataset.zoom);
+              var transformAfterZoom = viewport.style.transform;
+
+              frame.style.flex = '0 0 auto';
+              frame.style.width = '600px';
+              frame.style.height = '300px';
+              window.dispatchEvent(new Event('resize'));
+              var zoomAfterResizeEvent = Number(viewport.dataset.zoom);
+              var baselineAfterResizeEvent = Number(viewport.dataset.zoomBaseline);
+              modal.querySelector('.mermaid-modal-zoom-reset').click();
+              var zoomAfterReset = Number(viewport.dataset.zoom);
+              var baselineAfterResizeReset = Number(viewport.dataset.zoomBaseline);
+              var panXAfterReset = viewport.dataset.panX;
+              var panYAfterReset = viewport.dataset.panY;
+              var transformAfterReset = viewport.style.transform;
+              viewport.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, button: 0 }));
+              modal.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+              var stayedOpenAfterDragReleaseOnBackdrop = document.querySelector('.mermaid-modal') !== null;
+
+              expand.style.visibility = 'hidden';
+              modal.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+
+              return JSON.stringify({
+                modalOpened: modal !== null,
+                bodyLockedAfterOpen: bodyLockedAfterOpen,
+                htmlLockedAfterOpen: htmlLockedAfterOpen,
+                modalSVGWidthAttribute: modalSVG.getAttribute('width'),
+                modalSVGHeightAttribute: modalSVG.getAttribute('height'),
+                modalSVGStyleWidth: modalSVG.style.width,
+                modalSVGStyleHeight: modalSVG.style.height,
+                modalSVGStyleMaxWidth: modalSVG.style.maxWidth,
+                baselineZoom: baselineZoom,
+                initialZoom: initialZoom,
+                zoomAfterZoomIn: zoomAfterZoomIn,
+                zoomAfterResizeEvent: zoomAfterResizeEvent,
+                baselineAfterResizeEvent: baselineAfterResizeEvent,
+                zoomAfterReset: zoomAfterReset,
+                baselineAfterResizeReset: baselineAfterResizeReset,
+                panXAfterReset: panXAfterReset,
+                panYAfterReset: panYAfterReset,
+                transformAfterZoom: transformAfterZoom,
+                transformAfterReset: transformAfterReset,
+                stayedOpenAfterDragReleaseOnBackdrop: stayedOpenAfterDragReleaseOnBackdrop,
+                modalExistsAfterClose: document.querySelector('.mermaid-modal') !== null,
+                bodyLockedAfterClose: document.body.classList.contains('skimdown-mermaid-modal-open'),
+                htmlLockedAfterClose: document.documentElement.classList.contains('skimdown-mermaid-modal-open'),
+                focusRestoredToContainer: document.activeElement === document.querySelector('.mermaid-container'),
+                originalMarkerID: originalMarkerID,
+                modalMarkerID: modalMarkerID,
+                modalMarkerEnd: modalMarkerEnd
+              });
+            })();
+            """,
+            in: webView
+        )
+        let result = try JSONDecoder().decode(MermaidExpandPaneResult.self, from: Data(resultJSON.utf8))
+
+        XCTAssertTrue(result.modalOpened)
+        XCTAssertTrue(result.bodyLockedAfterOpen)
+        XCTAssertTrue(result.htmlLockedAfterOpen)
+        XCTAssertEqual(result.modalSVGWidthAttribute, "1200")
+        XCTAssertEqual(result.modalSVGHeightAttribute, "240")
+        XCTAssertEqual(result.modalSVGStyleWidth, "1200px")
+        XCTAssertEqual(result.modalSVGStyleHeight, "240px")
+        XCTAssertEqual(result.modalSVGStyleMaxWidth, "none")
+        XCTAssertLessThan(result.baselineZoom, 1)
+        XCTAssertEqual(result.initialZoom, result.baselineZoom, accuracy: 0.001)
+        XCTAssertGreaterThan(result.zoomAfterZoomIn, result.baselineZoom)
+        XCTAssertTrue(result.transformAfterZoom.contains("scale("))
+        XCTAssertEqual(result.zoomAfterResizeEvent, result.zoomAfterZoomIn, accuracy: 0.001)
+        XCTAssertEqual(result.baselineAfterResizeEvent, result.baselineZoom, accuracy: 0.001)
+        XCTAssertLessThan(result.baselineAfterResizeReset, result.baselineZoom)
+        XCTAssertEqual(result.baselineAfterResizeReset, 0.5, accuracy: 0.001)
+        XCTAssertEqual(result.zoomAfterReset, result.baselineAfterResizeReset, accuracy: 0.001)
+        XCTAssertEqual(result.panXAfterReset, "0")
+        XCTAssertEqual(result.panYAfterReset, "0")
+        if result.baselineAfterResizeReset == 1 {
+            XCTAssertEqual(result.transformAfterReset, "")
+        } else {
+            XCTAssertTrue(result.transformAfterReset.contains("scale(\(result.baselineAfterResizeReset))"))
+        }
+        XCTAssertTrue(result.stayedOpenAfterDragReleaseOnBackdrop)
+        XCTAssertFalse(result.modalExistsAfterClose)
+        XCTAssertFalse(result.bodyLockedAfterClose)
+        XCTAssertFalse(result.htmlLockedAfterClose)
+        XCTAssertTrue(result.focusRestoredToContainer)
+        XCTAssertNotEqual(result.originalMarkerID, result.modalMarkerID)
+        XCTAssertEqual(result.modalMarkerEnd, "url(#\(result.modalMarkerID))")
+    }
+
+    @MainActor
     func testSearchDoesNotMatchAcrossBlockBoundaries() async throws {
         let webView = try await renderMarkdown(
             """
@@ -366,7 +507,9 @@ final class RendererAnchorTests: XCTestCase {
     @MainActor
     private func renderMarkdown(
         _ markdown: String,
-        copyCodeMessageHandler: WKScriptMessageHandler? = nil
+        copyCodeMessageHandler: WKScriptMessageHandler? = nil,
+        additionalScripts: [String] = [],
+        additionalStyles: [String] = []
     ) async throws -> WKWebView {
         let configuration = WKWebViewConfiguration()
         if let copyCodeMessageHandler {
@@ -384,19 +527,29 @@ final class RendererAnchorTests: XCTestCase {
         }
         webView.navigationDelegate = navigationDelegate
 
-        webView.loadHTMLString(try rendererHTML(markdown: markdown), baseURL: Bundle.main.bundleURL)
+        webView.loadHTMLString(
+            try rendererHTML(markdown: markdown, additionalScripts: additionalScripts, additionalStyles: additionalStyles),
+            baseURL: Bundle.main.bundleURL
+        )
         await fulfillment(of: [navigationFinished], timeout: 5)
         webView.navigationDelegate = nil
 
         return webView
     }
 
-    private func rendererHTML(markdown: String) throws -> String {
-        let scripts = try [
+    private func rendererHTML(markdown: String, additionalScripts: [String] = [], additionalStyles: [String] = []) throws -> String {
+        let baseScripts = try [
             "vendor/markdown-it/markdown-it.min.js",
-            "vendor/dompurify/purify.min.js",
+            "vendor/dompurify/purify.min.js"
+        ].map(readWebResource)
+        let rendererScripts = try [
             "renderer.js"
-        ].map(readWebResource).joined(separator: "\n")
+        ].map(readWebResource)
+        let scripts = (
+            baseScripts +
+            additionalScripts +
+            rendererScripts
+        ).joined(separator: "\n")
 
         let payload: [String: Any] = [
             "markdown": markdown,
@@ -414,6 +567,7 @@ final class RendererAnchorTests: XCTestCase {
         <html>
           <head>
             <meta charset="utf-8">
+            <style>\(additionalStyles.joined(separator: "\n"))</style>
           </head>
           <body>
             <main id="content"></main>
@@ -458,6 +612,74 @@ final class RendererAnchorTests: XCTestCase {
             }
         }
     }
+
+    @MainActor
+    private func waitForJavaScriptCondition(_ script: String, in webView: WKWebView) async throws {
+        let timeout = Date().addingTimeInterval(2)
+        while Date() < timeout {
+            let result = try await evaluateStringJavaScript("String(Boolean(\(script)))", in: webView)
+            if result == "true" {
+                return
+            }
+            try await Task.sleep(nanoseconds: 50_000_000)
+        }
+        throw RendererAnchorTestError.scriptEvaluationFailed("Timed out waiting for JavaScript condition: \(script)")
+    }
+
+    private static let mermaidStubScript = """
+    window.mermaid = {
+      initialize: function () {},
+      run: function (options) {
+        (options.nodes || []).forEach(function (node) {
+          node.innerHTML = [
+            '<svg id="diagram" viewBox="0 0 1200 240" width="100%" style="max-width: 1200px;" xmlns="http://www.w3.org/2000/svg">',
+            '<defs><marker id="arrowhead" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto"><path d="M0,0 L0,6 L9,3 z"></path></marker></defs>',
+            '<style>#arrowhead path { fill: currentColor; }</style>',
+            '<path id="flow-line" d="M24 96 H1160" marker-end="url(#arrowhead)"></path>',
+            '<text x="24" y="72">Wide Mermaid flow</text>',
+            '</svg>'
+          ].join('');
+        });
+        return Promise.resolve();
+      }
+    };
+    """
+
+    private static let mermaidModalTestStyle = """
+    html, body {
+      width: 800px;
+      height: 600px;
+      margin: 0;
+    }
+    .mermaid-modal {
+      position: fixed;
+      inset: 0;
+      display: flex;
+      padding: 0;
+    }
+    .mermaid-modal-panel {
+      display: flex;
+      flex: 1 1 auto;
+      flex-direction: column;
+      min-width: 0;
+      min-height: 0;
+    }
+    .mermaid-modal-header {
+      flex: 0 0 50px;
+    }
+    .mermaid-modal-frame {
+      display: flex;
+      flex: 1 1 auto;
+      align-items: center;
+      justify-content: center;
+      min-height: 0;
+      overflow: hidden;
+      padding: 0;
+    }
+    .mermaid-modal-viewport {
+      flex: 0 0 auto;
+    }
+    """
 }
 
 private enum RendererAnchorTestError: Error {
@@ -483,6 +705,36 @@ private struct SearchAcrossColorCodeResult: Decodable {
 private struct MermaidColorExclusionResult: Decodable {
     let mermaidSwatches: Int
     let paragraphSwatches: Int
+}
+
+private struct MermaidExpandPaneResult: Decodable {
+    let modalOpened: Bool
+    let bodyLockedAfterOpen: Bool
+    let htmlLockedAfterOpen: Bool
+    let modalSVGWidthAttribute: String
+    let modalSVGHeightAttribute: String
+    let modalSVGStyleWidth: String
+    let modalSVGStyleHeight: String
+    let modalSVGStyleMaxWidth: String
+    let baselineZoom: Double
+    let initialZoom: Double
+    let zoomAfterZoomIn: Double
+    let zoomAfterResizeEvent: Double
+    let baselineAfterResizeEvent: Double
+    let zoomAfterReset: Double
+    let baselineAfterResizeReset: Double
+    let panXAfterReset: String
+    let panYAfterReset: String
+    let transformAfterZoom: String
+    let transformAfterReset: String
+    let stayedOpenAfterDragReleaseOnBackdrop: Bool
+    let modalExistsAfterClose: Bool
+    let bodyLockedAfterClose: Bool
+    let htmlLockedAfterClose: Bool
+    let focusRestoredToContainer: Bool
+    let originalMarkerID: String
+    let modalMarkerID: String
+    let modalMarkerEnd: String
 }
 
 private struct SearchBlockBoundaryResult: Decodable {


### PR DESCRIPTION
## Summary
- Add an expanded WebView modal for Mermaid diagrams with zoom, reset, panning, Escape/Close dismissal, scroll lock, and focus restoration.
- Normalize Mermaid SVG sizing in the expanded pane so `width="100%"`/inline `max-width` output does not collapse to the original card size.
- Make initial display and Reset use contain-fit sizing, including recalculating fit after app window resize.
- Add WKWebView renderer regression coverage for expanded sizing, SVG ID remapping, reset behavior, and focus cleanup.

## Validation
- `node --check src/SkimDown/Resources/Web/renderer.js`
- `xcodebuild test -project src/SkimDown.xcodeproj -scheme SkimDown -destination 'platform=macOS' -derivedDataPath build/DerivedData -only-testing:SkimDownTests/RendererAnchorTests/testMermaidExpandPaneOpensZoomsAndCloses`
- `make test`
- `make build`