### PR TITLE
Use available preview width and anchor TOC beside content

### DIFF
--- a/src/SkimDown/App/DocumentWindowController.swift
+++ b/src/SkimDown/App/DocumentWindowController.swift
@@ -38,6 +38,8 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, Side
         rawValue: NSLayoutConstraint.Priority.defaultLow.rawValue + 10
     )
     private static let tableOfContentsWidth: CGFloat = 260
+    private static let tableOfContentsTrailingInset: CGFloat = 16
+    private static let tableOfContentsReservedGutter: CGFloat = 24
     private static let tableOfContentsVerticalInset: CGFloat = 24
 
     var isEmpty: Bool {
@@ -486,7 +488,7 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, Side
             emptyStateView.topAnchor.constraint(equalTo: contentRootView.topAnchor),
             emptyStateView.bottomAnchor.constraint(equalTo: contentRootView.bottomAnchor),
 
-            tableOfContentsViewController.view.trailingAnchor.constraint(equalTo: contentRootView.trailingAnchor, constant: -16),
+            tableOfContentsViewController.view.trailingAnchor.constraint(equalTo: contentRootView.trailingAnchor, constant: -Self.tableOfContentsTrailingInset),
             tableOfContentsViewController.view.topAnchor.constraint(
                 equalTo: searchBarView.bottomAnchor,
                 constant: Self.tableOfContentsVerticalInset
@@ -693,7 +695,6 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, Side
             return
         }
 
-        clearTableOfContents()
         do {
             let canonicalFileURL = fileURL.skimdownCanonicalFileURL
             let shouldPreserveScrollPosition = preserveScrollPosition
@@ -708,6 +709,7 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, Side
             sidebarViewController.selectFile(fileURL)
             emptyStateView.isHidden = true
             markdownWebView.isHidden = false
+            clearTableOfContents(reserveWidthWhileLoading: settings.isTableOfContentsVisible)
             markdownWebView.render(
                 markdown: markdown,
                 currentFileURL: fileURL,
@@ -775,12 +777,12 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, Side
         }
     }
 
-    private func clearTableOfContents() {
+    private func clearTableOfContents(reserveWidthWhileLoading: Bool = false) {
         hasLoadedTableOfContents = false
         tableOfContentsViewController.update(items: [])
         tableOfContentsViewController.setActiveHeadingID(nil)
         updateTableOfContentsHeight()
-        updateTableOfContentsVisibility()
+        updateTableOfContentsVisibility(reserveWidthWhileLoading: reserveWidthWhileLoading)
     }
 
     private func updateTableOfContentsHeight() {
@@ -794,11 +796,18 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, Side
         contentRootView.needsLayout = true
     }
 
-    private func updateTableOfContentsVisibility() {
-        tableOfContentsViewController.view.isHidden = !settings.isTableOfContentsVisible
-            || !hasLoadedTableOfContents
-            || markdownWebView.isHidden
-            || selectedFileURL == nil
+    private func updateTableOfContentsVisibility(reserveWidthWhileLoading: Bool = false) {
+        let canShowTableOfContents = settings.isTableOfContentsVisible
+            && !markdownWebView.isHidden
+            && selectedFileURL != nil
+        let isVisible = canShowTableOfContents && hasLoadedTableOfContents
+        tableOfContentsViewController.view.isHidden = !isVisible
+        let shouldReserveWidth = isVisible || (reserveWidthWhileLoading && canShowTableOfContents)
+        markdownWebView.setReservedTrailingWidth(shouldReserveWidth ? Self.tableOfContentsReservedTrailingWidth : 0)
+    }
+
+    private static var tableOfContentsReservedTrailingWidth: Double {
+        Double(tableOfContentsWidth + tableOfContentsTrailingInset + tableOfContentsReservedGutter)
     }
 
     private func performSearch(scrollToMatch: Bool = true) {

--- a/src/SkimDown/App/DocumentWindowController.swift
+++ b/src/SkimDown/App/DocumentWindowController.swift
@@ -31,6 +31,8 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, Side
     private var scrollPositions: [URL: Double] = [:]
     private var isInitialLayoutComplete = false
     private var hasLoadedTableOfContents = false
+    private var isTableOfContentsMetricsRequestInFlight = false
+    private var needsTableOfContentsMetricsRefresh = false
 
     /// Give the sidebar a slightly higher holding priority so the content side
     /// absorbs resizing. This avoids sidebar width snapping back after AppKit
@@ -827,26 +829,50 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, Side
             containerWidth: containerWidth
         )
         guard !tableOfContentsViewController.view.isHidden else {
+            needsTableOfContentsMetricsRefresh = false
             return
         }
 
+        requestTableOfContentsMetrics(containerWidth: containerWidth)
+    }
+
+    private func requestTableOfContentsMetrics(containerWidth: CGFloat) {
+        guard !isTableOfContentsMetricsRequestInFlight else {
+            needsTableOfContentsMetricsRefresh = true
+            return
+        }
+
+        isTableOfContentsMetricsRequestInFlight = true
+        needsTableOfContentsMetricsRefresh = false
         markdownWebView.previewLayoutMetrics { [weak self] metrics in
-            guard let self,
-                  !self.tableOfContentsViewController.view.isHidden else {
+            guard let self else {
+                return
+            }
+            self.isTableOfContentsMetricsRequestInFlight = false
+            let shouldRefresh = self.needsTableOfContentsMetricsRefresh
+            self.needsTableOfContentsMetricsRefresh = false
+
+            guard !self.tableOfContentsViewController.view.isHidden else {
+                if shouldRefresh {
+                    self.updateTableOfContentsPlacement()
+                }
                 return
             }
 
             let currentContainerWidth = self.contentRootView.bounds.width
-            guard currentContainerWidth > 0,
-                  let metrics,
-                  abs(CGFloat(metrics.viewportWidth) - currentContainerWidth) <= 20 else {
-                return
+            if currentContainerWidth > 0,
+               let metrics,
+               abs(currentContainerWidth - containerWidth) <= 1,
+               abs(CGFloat(metrics.viewportWidth) - containerWidth) <= 20 {
+                self.applyTableOfContentsPlacement(
+                    contentRight: CGFloat(metrics.contentRight),
+                    containerWidth: currentContainerWidth
+                )
             }
 
-            self.applyTableOfContentsPlacement(
-                contentRight: CGFloat(metrics.contentRight),
-                containerWidth: currentContainerWidth
-            )
+            if shouldRefresh || abs(currentContainerWidth - containerWidth) > 1 {
+                self.updateTableOfContentsPlacement()
+            }
         }
     }
 

--- a/src/SkimDown/App/DocumentWindowController.swift
+++ b/src/SkimDown/App/DocumentWindowController.swift
@@ -21,6 +21,7 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, Side
     private var contentItem: NSSplitViewItem!
     private var searchBarHeightConstraint: NSLayoutConstraint!
     private var tableOfContentsHeightConstraint: NSLayoutConstraint!
+    private var tableOfContentsLeadingConstraint: NSLayoutConstraint!
     private var session: FolderSession?
     private var fileWatcher = FileWatcher()
     private var settings: AppSettings
@@ -389,6 +390,7 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, Side
 
     func windowDidResize(_ notification: Notification) {
         updateTableOfContentsHeight()
+        updateTableOfContentsPlacement()
     }
 
     func emptyStateViewDidRequestOpenFolder(_ view: EmptyStateView) {
@@ -472,6 +474,8 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, Side
         contentRootView.addSubview(dragOverlayView, positioned: .above, relativeTo: nil)
         documentContentViewController.view = contentRootView
 
+        tableOfContentsLeadingConstraint = tableOfContentsViewController.view.leadingAnchor.constraint(equalTo: contentRootView.leadingAnchor)
+
         NSLayoutConstraint.activate([
             searchBarView.leadingAnchor.constraint(equalTo: contentRootView.leadingAnchor),
             searchBarView.trailingAnchor.constraint(equalTo: contentRootView.trailingAnchor),
@@ -488,7 +492,7 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, Side
             emptyStateView.topAnchor.constraint(equalTo: contentRootView.topAnchor),
             emptyStateView.bottomAnchor.constraint(equalTo: contentRootView.bottomAnchor),
 
-            tableOfContentsViewController.view.trailingAnchor.constraint(equalTo: contentRootView.trailingAnchor, constant: -Self.tableOfContentsTrailingInset),
+            tableOfContentsLeadingConstraint,
             tableOfContentsViewController.view.topAnchor.constraint(
                 equalTo: searchBarView.bottomAnchor,
                 constant: Self.tableOfContentsVerticalInset
@@ -529,6 +533,7 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, Side
 
     @objc private func splitViewDidResizeSubviewsNotification(_ notification: Notification) {
         updateTableOfContentsHeight()
+        updateTableOfContentsPlacement()
 
         guard isInitialLayoutComplete,
               !sidebarItem.isCollapsed,
@@ -804,10 +809,64 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, Side
         tableOfContentsViewController.view.isHidden = !isVisible
         let shouldReserveWidth = isVisible || (reserveWidthWhileLoading && canShowTableOfContents)
         markdownWebView.setReservedTrailingWidth(shouldReserveWidth ? Self.tableOfContentsReservedTrailingWidth : 0)
+        updateTableOfContentsPlacement()
     }
 
     private static var tableOfContentsReservedTrailingWidth: Double {
         Double(tableOfContentsWidth + tableOfContentsTrailingInset + tableOfContentsReservedGutter)
+    }
+
+    private func updateTableOfContentsPlacement() {
+        let containerWidth = contentRootView.bounds.width
+        guard containerWidth > 0 else {
+            return
+        }
+
+        applyTableOfContentsPlacement(
+            contentRight: estimatedPreviewContentRight(containerWidth: containerWidth),
+            containerWidth: containerWidth
+        )
+        guard !tableOfContentsViewController.view.isHidden else {
+            return
+        }
+
+        markdownWebView.previewLayoutMetrics { [weak self] metrics in
+            guard let self,
+                  !self.tableOfContentsViewController.view.isHidden else {
+                return
+            }
+
+            let currentContainerWidth = self.contentRootView.bounds.width
+            guard currentContainerWidth > 0,
+                  let metrics,
+                  abs(CGFloat(metrics.viewportWidth) - currentContainerWidth) <= 20 else {
+                return
+            }
+
+            self.applyTableOfContentsPlacement(
+                contentRight: CGFloat(metrics.contentRight),
+                containerWidth: currentContainerWidth
+            )
+        }
+    }
+
+    private func applyTableOfContentsPlacement(contentRight: CGFloat?, containerWidth: CGFloat) {
+        tableOfContentsLeadingConstraint.constant = TableOfContentsPlacement.leadingOffset(
+            contentRight: contentRight,
+            containerWidth: containerWidth,
+            paneWidth: Self.tableOfContentsWidth,
+            trailingInset: Self.tableOfContentsTrailingInset,
+            gutter: Self.tableOfContentsReservedGutter
+        )
+        contentRootView.needsLayout = true
+    }
+
+    private func estimatedPreviewContentRight(containerWidth: CGFloat) -> CGFloat {
+        PreviewContentLayout.estimatedContentRight(
+            containerWidth: containerWidth,
+            fontSize: CGFloat(settings.fontSize),
+            reservedTrailingWidth: CGFloat(Self.tableOfContentsReservedTrailingWidth)
+        )
     }
 
     private func performSearch(scrollToMatch: Bool = true) {

--- a/src/SkimDown/App/DocumentWindowController.swift
+++ b/src/SkimDown/App/DocumentWindowController.swift
@@ -335,7 +335,7 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, Side
         settings.isTableOfContentsVisible.toggle()
         settingsStore.isTableOfContentsVisible = settings.isTableOfContentsVisible
         updateTableOfContentsHeight()
-        updateTableOfContentsVisibility()
+        updateTableOfContentsVisibility(reserveWidthWhileLoading: settings.isTableOfContentsVisible)
     }
 
     func moveSidebar(to position: SidebarPosition) {

--- a/src/SkimDown/App/TableOfContentsPlacement.swift
+++ b/src/SkimDown/App/TableOfContentsPlacement.swift
@@ -1,0 +1,42 @@
+import CoreGraphics
+
+enum TableOfContentsPlacement {
+    static func leadingOffset(
+        contentRight: CGFloat?,
+        containerWidth: CGFloat,
+        paneWidth: CGFloat,
+        trailingInset: CGFloat,
+        gutter: CGFloat
+    ) -> CGFloat {
+        let trailingLeading = max(0, containerWidth - trailingInset - paneWidth)
+        guard let contentRight, contentRight.isFinite, contentRight > 0 else {
+            return trailingLeading
+        }
+
+        return max(0, min(contentRight + gutter, trailingLeading))
+    }
+}
+
+enum PreviewContentLayout {
+    private static let minimumInlinePadding: CGFloat = 40
+    private static let preferredInlinePaddingRatio: CGFloat = 0.08
+    private static let maximumInlinePadding: CGFloat = 120
+    private static let contentMaxWidthInRem: CGFloat = 92
+
+    static func estimatedContentRight(
+        containerWidth: CGFloat,
+        fontSize: CGFloat,
+        reservedTrailingWidth: CGFloat
+    ) -> CGFloat {
+        let leftPadding = inlinePadding(containerWidth: containerWidth)
+        let rightPadding = max(leftPadding, reservedTrailingWidth)
+        let bodyContentWidth = max(0, containerWidth - leftPadding - rightPadding)
+        let contentWidth = min(bodyContentWidth, contentMaxWidthInRem * fontSize)
+        let leadingMargin = max(0, (bodyContentWidth - contentWidth) / 2)
+        return leftPadding + leadingMargin + contentWidth
+    }
+
+    private static func inlinePadding(containerWidth: CGFloat) -> CGFloat {
+        min(max(containerWidth * preferredInlinePaddingRatio, minimumInlinePadding), maximumInlinePadding)
+    }
+}

--- a/src/SkimDown/Resources/Web/renderer.js
+++ b/src/SkimDown/Resources/Web/renderer.js
@@ -3,7 +3,13 @@
   let searchMatches = [];
   let currentSearchIndex = -1;
   let tableResizeObserver = null;
+  let tableMutationObserver = null;
   let tableResizeHandler = null;
+  let tableLayoutFrame = null;
+  let tableCueFrame = null;
+  let pendingTableLayoutWrappers = new Set();
+  let pendingTableCueWrappers = new Set();
+  let tableImagesWithLayoutListener = new WeakSet();
   let mermaidResizeObserver = null;
   let mermaidResizeHandler = null;
   let activeHeadingIntersectionObserver = null;
@@ -20,6 +26,7 @@
   let mermaidModalSequence = 0;
   const IMAGE_READY_TIMEOUT_MS = 3000;
   const CODE_COPY_FEEDBACK_RESET_MS = 1500;
+  const TABLE_SCROLL_TOLERANCE = 1;
   // Matches standalone #RGB, #RGBA, #RRGGBB, and #RRGGBBAA color codes.
   const COLOR_CODE_PATTERN_SOURCE = "(^|[^\\w-])(#(?:[0-9A-Fa-f]{8}|[0-9A-Fa-f]{6}|[0-9A-Fa-f]{4}|[0-9A-Fa-f]{3}))(?![\\w-])";
   const COLOR_CODE_DETECTION_PATTERN = new RegExp(COLOR_CODE_PATTERN_SOURCE);
@@ -589,10 +596,25 @@
       tableResizeObserver.disconnect();
       tableResizeObserver = null;
     }
+    if (tableMutationObserver) {
+      tableMutationObserver.disconnect();
+      tableMutationObserver = null;
+    }
     if (tableResizeHandler) {
       window.removeEventListener("resize", tableResizeHandler);
       tableResizeHandler = null;
     }
+    if (tableLayoutFrame !== null) {
+      window.cancelAnimationFrame(tableLayoutFrame);
+      tableLayoutFrame = null;
+    }
+    if (tableCueFrame !== null) {
+      window.cancelAnimationFrame(tableCueFrame);
+      tableCueFrame = null;
+    }
+    pendingTableLayoutWrappers.clear();
+    pendingTableCueWrappers.clear();
+    tableImagesWithLayoutListener = new WeakSet();
 
     const wrappers = Array.from(content.querySelectorAll(".table-scroll"));
     if (wrappers.length === 0) {
@@ -601,7 +623,8 @@
 
     wrappers.forEach(function (wrapper) {
       const viewport = tableScrollViewport(wrapper);
-      updateTableScrollCue(wrapper);
+      updateTableLayout(wrapper);
+      registerTableImageLayoutUpdates(wrapper);
       viewport.addEventListener("scroll", function () {
         updateTableScrollCue(wrapper);
       }, { passive: true });
@@ -622,7 +645,7 @@
             }
           }
         });
-        wrappersToUpdate.forEach(updateTableScrollCue);
+        scheduleTableLayoutUpdates(wrappersToUpdate);
       });
 
       wrappers.forEach(function (wrapper) {
@@ -634,27 +657,176 @@
           tableResizeObserver.observe(table);
         }
       });
-    } else {
-      tableResizeHandler = function () {
-        wrappers.forEach(updateTableScrollCue);
-      };
-      window.addEventListener("resize", tableResizeHandler);
     }
 
-    window.requestAnimationFrame(function () {
-      wrappers.forEach(updateTableScrollCue);
+    if ("MutationObserver" in window) {
+      tableMutationObserver = new MutationObserver(function (entries) {
+        const wrappersToUpdate = new Set();
+        entries.forEach(function (entry) {
+          const wrapper = tableWrapperForNode(entry.target);
+          if (wrapper) {
+            wrappersToUpdate.add(wrapper);
+          }
+          entry.addedNodes.forEach(function (node) {
+            const addedWrapper = tableWrapperForNode(node);
+            if (addedWrapper) {
+              wrappersToUpdate.add(addedWrapper);
+            }
+          });
+        });
+        wrappersToUpdate.forEach(function (wrapper) {
+          registerTableImageLayoutUpdates(wrapper);
+          updateTableLayout(wrapper);
+        });
+      });
+      wrappers.forEach(function (wrapper) {
+        const table = wrapper.querySelector("table");
+        if (table) {
+          tableMutationObserver.observe(table, {
+            attributes: true,
+            characterData: true,
+            childList: true,
+            subtree: true
+          });
+        }
+      });
+    }
+
+    tableResizeHandler = function () {
+      scheduleTableLayoutUpdates(wrappers);
+    };
+    window.addEventListener("resize", tableResizeHandler);
+
+    scheduleTableLayoutUpdates(wrappers);
+    scheduleTableCueUpdates(wrappers);
+  }
+
+  function scheduleTableLayoutUpdates(wrappers) {
+    addPendingTableWrappers(pendingTableLayoutWrappers, wrappers);
+    if (pendingTableLayoutWrappers.size === 0 || tableLayoutFrame !== null) {
+      return;
+    }
+    tableLayoutFrame = window.requestAnimationFrame(function () {
+      tableLayoutFrame = null;
+      const wrappersToUpdate = Array.from(pendingTableLayoutWrappers);
+      pendingTableLayoutWrappers.clear();
+      wrappersToUpdate.forEach(updateTableLayout);
     });
+  }
+
+  function scheduleTableCueUpdates(wrappers) {
+    addPendingTableWrappers(pendingTableCueWrappers, wrappers);
+    if (pendingTableCueWrappers.size === 0 || tableCueFrame !== null) {
+      return;
+    }
+    tableCueFrame = window.requestAnimationFrame(function () {
+      tableCueFrame = null;
+      const wrappersToUpdate = Array.from(pendingTableCueWrappers);
+      pendingTableCueWrappers.clear();
+      wrappersToUpdate.forEach(updateTableScrollCue);
+    });
+  }
+
+  function addPendingTableWrappers(target, wrappers) {
+    wrappers.forEach(function (wrapper) {
+      if (wrapper && wrapper.isConnected) {
+        target.add(wrapper);
+      }
+    });
+  }
+
+  function tableWrapperForNode(node) {
+    if (!node) {
+      return null;
+    }
+    if (node.nodeType === Node.ELEMENT_NODE) {
+      return node.classList && node.classList.contains("table-scroll")
+        ? node
+        : node.closest && node.closest(".table-scroll");
+    }
+    return node.parentElement && node.parentElement.closest(".table-scroll");
+  }
+
+  function registerTableImageLayoutUpdates(wrapper) {
+    wrapper.querySelectorAll("img").forEach(function (image) {
+      if (tableImagesWithLayoutListener.has(image)) {
+        return;
+      }
+      tableImagesWithLayoutListener.add(image);
+      const update = function () {
+        if (wrapper.isConnected) {
+          updateTableLayout(wrapper);
+        }
+      };
+      image.addEventListener("load", update, { once: true });
+      image.addEventListener("error", update, { once: true });
+    });
+  }
+
+  function updateTableLayout(wrapper) {
+    const wideMetrics = tableWideMetrics(wrapper);
+    if (wideMetrics) {
+      wrapper.style.setProperty("--table-wide-width", wideMetrics.width + "px");
+      wrapper.style.setProperty("--table-wide-margin-left", wideMetrics.marginLeft + "px");
+      wrapper.classList.add("table-scroll-wide");
+    } else {
+      wrapper.classList.remove("table-scroll-wide");
+      wrapper.style.removeProperty("--table-wide-width");
+      wrapper.style.removeProperty("--table-wide-margin-left");
+    }
+    updateTableScrollCue(wrapper);
+  }
+
+  function tableWideMetrics(wrapper) {
+    const viewport = tableScrollViewport(wrapper);
+    const content = document.getElementById("content");
+    if (!viewport || !content) {
+      return null;
+    }
+
+    const contentWidth = content.clientWidth;
+    const wideArea = availableTableWideArea();
+    if (wideArea.width <= contentWidth + TABLE_SCROLL_TOLERANCE) {
+      return null;
+    }
+
+    const wasWide = wrapper.classList.contains("table-scroll-wide");
+    if (wasWide) {
+      wrapper.classList.remove("table-scroll-wide");
+    }
+    const overflowsNormalColumn = viewport.scrollWidth - viewport.clientWidth > TABLE_SCROLL_TOLERANCE;
+    const normalLeft = wrapper.getBoundingClientRect().left;
+    if (wasWide) {
+      wrapper.classList.add("table-scroll-wide");
+    }
+    if (!overflowsNormalColumn) {
+      return null;
+    }
+
+    return {
+      width: wideArea.width,
+      marginLeft: wideArea.left - normalLeft
+    };
+  }
+
+  function availableTableWideArea() {
+    const bodyStyle = window.getComputedStyle(document.body);
+    const paddingLeft = parseFloat(bodyStyle.paddingLeft) || 0;
+    const paddingRight = parseFloat(bodyStyle.paddingRight) || 0;
+    return {
+      left: paddingLeft,
+      width: Math.max(0, window.innerWidth - paddingLeft - paddingRight)
+    };
   }
 
   function updateTableScrollCue(wrapper) {
     const viewport = tableScrollViewport(wrapper);
-    const tolerance = 1;
     const maxScrollLeft = viewport.scrollWidth - viewport.clientWidth;
-    const isOverflowing = maxScrollLeft > tolerance;
+    const isOverflowing = maxScrollLeft > TABLE_SCROLL_TOLERANCE;
     const scrollLeft = Math.max(0, viewport.scrollLeft);
 
-    wrapper.classList.toggle("can-scroll-left", isOverflowing && scrollLeft > tolerance);
-    wrapper.classList.toggle("can-scroll-right", isOverflowing && scrollLeft < maxScrollLeft - tolerance);
+    wrapper.classList.toggle("can-scroll-left", isOverflowing && scrollLeft > TABLE_SCROLL_TOLERANCE);
+    wrapper.classList.toggle("can-scroll-right", isOverflowing && scrollLeft < maxScrollLeft - TABLE_SCROLL_TOLERANCE);
   }
 
   function tableScrollViewport(wrapper) {

--- a/src/SkimDown/Resources/Web/renderer.js
+++ b/src/SkimDown/Resources/Web/renderer.js
@@ -3,13 +3,9 @@
   let searchMatches = [];
   let currentSearchIndex = -1;
   let tableResizeObserver = null;
-  let tableMutationObserver = null;
   let tableResizeHandler = null;
-  let tableLayoutFrame = null;
   let tableCueFrame = null;
-  let pendingTableLayoutWrappers = new Set();
   let pendingTableCueWrappers = new Set();
-  let tableImagesWithLayoutListener = new WeakSet();
   let mermaidResizeObserver = null;
   let mermaidResizeHandler = null;
   let activeHeadingIntersectionObserver = null;
@@ -121,6 +117,7 @@
     }
     document.documentElement.dataset.theme = payload.theme || "system";
     document.documentElement.style.setProperty("--skimdown-font-size", String(payload.fontSize || 16) + "px");
+    applyReservedTrailingWidth(payload.reservedTrailingWidth);
     closeActiveMermaidModal();
 
     const content = document.getElementById("content");
@@ -148,6 +145,19 @@
     installUserInteractionWatcher(payload.renderID);
     installScrollPositionListener(payload.renderID);
     installActiveHeadingTracker(content, payload.renderID);
+  }
+
+  function setReservedTrailingWidth(value) {
+    applyReservedTrailingWidth(value);
+    updateAllTableScrollCues();
+    if (activeHeadingUpdateHandler) {
+      activeHeadingUpdateHandler();
+    }
+  }
+
+  function applyReservedTrailingWidth(value) {
+    const width = Math.max(0, Number(value) || 0);
+    document.documentElement.style.setProperty("--skimdown-reserved-trailing-width", width + "px");
   }
 
   function installScrollPositionListener(renderID) {
@@ -596,35 +606,23 @@
       tableResizeObserver.disconnect();
       tableResizeObserver = null;
     }
-    if (tableMutationObserver) {
-      tableMutationObserver.disconnect();
-      tableMutationObserver = null;
-    }
     if (tableResizeHandler) {
       window.removeEventListener("resize", tableResizeHandler);
       tableResizeHandler = null;
-    }
-    if (tableLayoutFrame !== null) {
-      window.cancelAnimationFrame(tableLayoutFrame);
-      tableLayoutFrame = null;
     }
     if (tableCueFrame !== null) {
       window.cancelAnimationFrame(tableCueFrame);
       tableCueFrame = null;
     }
-    pendingTableLayoutWrappers.clear();
     pendingTableCueWrappers.clear();
-    tableImagesWithLayoutListener = new WeakSet();
 
     const wrappers = Array.from(content.querySelectorAll(".table-scroll"));
     if (wrappers.length === 0) {
       return;
     }
-
     wrappers.forEach(function (wrapper) {
       const viewport = tableScrollViewport(wrapper);
-      updateTableLayout(wrapper);
-      registerTableImageLayoutUpdates(wrapper);
+      updateTableScrollCue(wrapper);
       viewport.addEventListener("scroll", function () {
         updateTableScrollCue(wrapper);
       }, { passive: true });
@@ -645,7 +643,7 @@
             }
           }
         });
-        scheduleTableLayoutUpdates(wrappersToUpdate);
+        scheduleTableCueUpdates(wrappersToUpdate);
       });
 
       wrappers.forEach(function (wrapper) {
@@ -659,59 +657,12 @@
       });
     }
 
-    if ("MutationObserver" in window) {
-      tableMutationObserver = new MutationObserver(function (entries) {
-        const wrappersToUpdate = new Set();
-        entries.forEach(function (entry) {
-          const wrapper = tableWrapperForNode(entry.target);
-          if (wrapper) {
-            wrappersToUpdate.add(wrapper);
-          }
-          entry.addedNodes.forEach(function (node) {
-            const addedWrapper = tableWrapperForNode(node);
-            if (addedWrapper) {
-              wrappersToUpdate.add(addedWrapper);
-            }
-          });
-        });
-        wrappersToUpdate.forEach(function (wrapper) {
-          registerTableImageLayoutUpdates(wrapper);
-          updateTableLayout(wrapper);
-        });
-      });
-      wrappers.forEach(function (wrapper) {
-        const table = wrapper.querySelector("table");
-        if (table) {
-          tableMutationObserver.observe(table, {
-            attributes: true,
-            characterData: true,
-            childList: true,
-            subtree: true
-          });
-        }
-      });
-    }
-
     tableResizeHandler = function () {
-      scheduleTableLayoutUpdates(wrappers);
+      scheduleTableCueUpdates(wrappers);
     };
     window.addEventListener("resize", tableResizeHandler);
 
-    scheduleTableLayoutUpdates(wrappers);
     scheduleTableCueUpdates(wrappers);
-  }
-
-  function scheduleTableLayoutUpdates(wrappers) {
-    addPendingTableWrappers(pendingTableLayoutWrappers, wrappers);
-    if (pendingTableLayoutWrappers.size === 0 || tableLayoutFrame !== null) {
-      return;
-    }
-    tableLayoutFrame = window.requestAnimationFrame(function () {
-      tableLayoutFrame = null;
-      const wrappersToUpdate = Array.from(pendingTableLayoutWrappers);
-      pendingTableLayoutWrappers.clear();
-      wrappersToUpdate.forEach(updateTableLayout);
-    });
   }
 
   function scheduleTableCueUpdates(wrappers) {
@@ -735,88 +686,8 @@
     });
   }
 
-  function tableWrapperForNode(node) {
-    if (!node) {
-      return null;
-    }
-    if (node.nodeType === Node.ELEMENT_NODE) {
-      return node.classList && node.classList.contains("table-scroll")
-        ? node
-        : node.closest && node.closest(".table-scroll");
-    }
-    return node.parentElement && node.parentElement.closest(".table-scroll");
-  }
-
-  function registerTableImageLayoutUpdates(wrapper) {
-    wrapper.querySelectorAll("img").forEach(function (image) {
-      if (tableImagesWithLayoutListener.has(image)) {
-        return;
-      }
-      tableImagesWithLayoutListener.add(image);
-      const update = function () {
-        if (wrapper.isConnected) {
-          updateTableLayout(wrapper);
-        }
-      };
-      image.addEventListener("load", update, { once: true });
-      image.addEventListener("error", update, { once: true });
-    });
-  }
-
-  function updateTableLayout(wrapper) {
-    const wideMetrics = tableWideMetrics(wrapper);
-    if (wideMetrics) {
-      wrapper.style.setProperty("--table-wide-width", wideMetrics.width + "px");
-      wrapper.style.setProperty("--table-wide-margin-left", wideMetrics.marginLeft + "px");
-      wrapper.classList.add("table-scroll-wide");
-    } else {
-      wrapper.classList.remove("table-scroll-wide");
-      wrapper.style.removeProperty("--table-wide-width");
-      wrapper.style.removeProperty("--table-wide-margin-left");
-    }
-    updateTableScrollCue(wrapper);
-  }
-
-  function tableWideMetrics(wrapper) {
-    const viewport = tableScrollViewport(wrapper);
-    const content = document.getElementById("content");
-    if (!viewport || !content) {
-      return null;
-    }
-
-    const contentWidth = content.clientWidth;
-    const wideArea = availableTableWideArea();
-    if (wideArea.width <= contentWidth + TABLE_SCROLL_TOLERANCE) {
-      return null;
-    }
-
-    const wasWide = wrapper.classList.contains("table-scroll-wide");
-    if (wasWide) {
-      wrapper.classList.remove("table-scroll-wide");
-    }
-    const overflowsNormalColumn = viewport.scrollWidth - viewport.clientWidth > TABLE_SCROLL_TOLERANCE;
-    const normalLeft = wrapper.getBoundingClientRect().left;
-    if (wasWide) {
-      wrapper.classList.add("table-scroll-wide");
-    }
-    if (!overflowsNormalColumn) {
-      return null;
-    }
-
-    return {
-      width: wideArea.width,
-      marginLeft: wideArea.left - normalLeft
-    };
-  }
-
-  function availableTableWideArea() {
-    const bodyStyle = window.getComputedStyle(document.body);
-    const paddingLeft = parseFloat(bodyStyle.paddingLeft) || 0;
-    const paddingRight = parseFloat(bodyStyle.paddingRight) || 0;
-    return {
-      left: paddingLeft,
-      width: Math.max(0, window.innerWidth - paddingLeft - paddingRight)
-    };
+  function updateAllTableScrollCues() {
+    document.querySelectorAll(".table-scroll").forEach(updateTableScrollCue);
   }
 
   function updateTableScrollCue(wrapper) {
@@ -2096,6 +1967,7 @@
 
   window.skimdown = {
     render: render,
+    setReservedTrailingWidth: setReservedTrailingWidth,
     performSearch: performSearch,
     nextSearch: nextSearch,
     previousSearch: previousSearch,

--- a/src/SkimDown/Resources/Web/renderer.js
+++ b/src/SkimDown/Resources/Web/renderer.js
@@ -160,6 +160,27 @@
     document.documentElement.style.setProperty("--skimdown-reserved-trailing-width", width + "px");
   }
 
+  function previewLayoutMetrics() {
+    const content = document.getElementById("content");
+    const viewportWidth = window.innerWidth || document.documentElement.clientWidth || 0;
+    if (!content) {
+      return {
+        contentLeft: 0,
+        contentRight: 0,
+        contentWidth: 0,
+        viewportWidth: viewportWidth
+      };
+    }
+
+    const rect = content.getBoundingClientRect();
+    return {
+      contentLeft: rect.left,
+      contentRight: rect.right,
+      contentWidth: rect.width,
+      viewportWidth: viewportWidth
+    };
+  }
+
   function installScrollPositionListener(renderID) {
     let pending = false;
     let lastPosted = null;
@@ -1968,6 +1989,7 @@
   window.skimdown = {
     render: render,
     setReservedTrailingWidth: setReservedTrailingWidth,
+    previewLayoutMetrics: previewLayoutMetrics,
     performSearch: performSearch,
     nextSearch: nextSearch,
     previousSearch: previousSearch,

--- a/src/SkimDown/Resources/Web/renderer.js
+++ b/src/SkimDown/Resources/Web/renderer.js
@@ -156,7 +156,8 @@
   }
 
   function applyReservedTrailingWidth(value) {
-    const width = Math.max(0, Number(value) || 0);
+    const numericWidth = Number(value);
+    const width = Number.isFinite(numericWidth) ? Math.max(0, numericWidth) : 0;
     document.documentElement.style.setProperty("--skimdown-reserved-trailing-width", width + "px");
   }
 

--- a/src/SkimDown/Resources/Web/skimdown.css
+++ b/src/SkimDown/Resources/Web/skimdown.css
@@ -1,6 +1,7 @@
 :root {
   color-scheme: light dark;
   --skimdown-font-size: 16px;
+  --skimdown-page-inline-padding: clamp(40px, 8vw, 120px);
   --skimdown-bg: #fbfbfd;
   --skimdown-fg: #20242c;
   --skimdown-muted: #69707d;
@@ -62,7 +63,7 @@ body {
 }
 
 body {
-  padding: 56px clamp(40px, 8vw, 120px) 96px;
+  padding: 56px var(--skimdown-page-inline-padding) 96px;
 }
 
 #content {
@@ -227,6 +228,12 @@ pre code {
   width: 100%;
   margin-bottom: 1.15em;
   --table-overflow-cue-edge: var(--skimdown-bg);
+}
+
+.table-scroll.table-scroll-wide {
+  width: var(--table-wide-width, calc(100vw - var(--skimdown-page-inline-padding) - var(--skimdown-page-inline-padding)));
+  max-width: none;
+  margin-left: var(--table-wide-margin-left, 0);
 }
 
 .table-scroll::before,

--- a/src/SkimDown/Resources/Web/skimdown.css
+++ b/src/SkimDown/Resources/Web/skimdown.css
@@ -2,6 +2,8 @@
   color-scheme: light dark;
   --skimdown-font-size: 16px;
   --skimdown-page-inline-padding: clamp(40px, 8vw, 120px);
+  --skimdown-reserved-trailing-width: 0px;
+  --skimdown-content-max-width: 92rem;
   --skimdown-bg: #fbfbfd;
   --skimdown-fg: #20242c;
   --skimdown-muted: #69707d;
@@ -63,11 +65,15 @@ body {
 }
 
 body {
-  padding: 56px var(--skimdown-page-inline-padding) 96px;
+  padding:
+    56px
+    max(var(--skimdown-page-inline-padding), var(--skimdown-reserved-trailing-width))
+    96px
+    var(--skimdown-page-inline-padding);
 }
 
 #content {
-  max-width: 980px;
+  max-width: var(--skimdown-content-max-width);
   margin: 0 auto;
 }
 
@@ -228,12 +234,6 @@ pre code {
   width: 100%;
   margin-bottom: 1.15em;
   --table-overflow-cue-edge: var(--skimdown-bg);
-}
-
-.table-scroll.table-scroll-wide {
-  width: var(--table-wide-width, calc(100vw - var(--skimdown-page-inline-padding) - var(--skimdown-page-inline-padding)));
-  max-width: none;
-  margin-left: var(--table-wide-margin-left, 0);
 }
 
 .table-scroll::before,

--- a/src/SkimDown/Viewer/MarkdownWebView.swift
+++ b/src/SkimDown/Viewer/MarkdownWebView.swift
@@ -72,6 +72,7 @@ final class MarkdownWebView: NSView, WKScriptMessageHandler, WKNavigationDelegat
     private var renderGeneration = 0
     private var pendingNavigation: PendingNavigation?
     private var observedScrollY: Double?
+    private var reservedTrailingWidth: Double = 0
 
     override init(frame frameRect: NSRect) {
         let configuration = WKWebViewConfiguration()
@@ -144,7 +145,8 @@ final class MarkdownWebView: NSView, WKScriptMessageHandler, WKNavigationDelegat
                 resolvedTheme: resolvedTheme,
                 fontSize: fontSize,
                 generation: generation,
-                restoreScrollY: effectiveScrollY
+                restoreScrollY: effectiveScrollY,
+                reservedTrailingWidth: reservedTrailingWidth
             )
             do {
                 let html = try Self.buildHTML(payload: payload, theme: theme, resolvedTheme: resolvedTheme, katexFontsURL: self.katexFontsURLString())
@@ -185,6 +187,12 @@ final class MarkdownWebView: NSView, WKScriptMessageHandler, WKNavigationDelegat
         observedScrollY
     }
 
+    func setReservedTrailingWidth(_ width: Double) {
+        let normalizedWidth = max(0, width)
+        reservedTrailingWidth = normalizedWidth
+        webView.evaluateJavaScript("window.skimdown && window.skimdown.setReservedTrailingWidth(\(normalizedWidth))")
+    }
+
     func showError(_ message: String, theme: AppTheme, resolvedTheme: ResolvedTheme?, fontSize: Double, completion: (() -> Void)? = nil) {
         let generation = advanceRenderGeneration()
         applyNativeAppearance(theme, resolvedTheme: resolvedTheme)
@@ -196,7 +204,8 @@ final class MarkdownWebView: NSView, WKScriptMessageHandler, WKNavigationDelegat
             resolvedTheme: resolvedTheme,
             fontSize: fontSize,
             generation: generation,
-            restoreScrollY: 0
+            restoreScrollY: 0,
+            reservedTrailingWidth: reservedTrailingWidth
         )
         do {
             loadHTML(
@@ -543,7 +552,8 @@ final class MarkdownWebView: NSView, WKScriptMessageHandler, WKNavigationDelegat
         resolvedTheme: ResolvedTheme?,
         fontSize: Double,
         generation: Int,
-        restoreScrollY: Double
+        restoreScrollY: Double,
+        reservedTrailingWidth: Double
     ) -> [String: Any] {
         let themeIsDark = isEffectiveThemeDark(theme, resolvedTheme: resolvedTheme)
         return [
@@ -555,7 +565,8 @@ final class MarkdownWebView: NSView, WKScriptMessageHandler, WKNavigationDelegat
             "themeIsDark": themeIsDark,
             "fontSize": fontSize,
             "renderID": generation,
-            "restoreScrollY": restoreScrollY
+            "restoreScrollY": restoreScrollY,
+            "reservedTrailingWidth": reservedTrailingWidth
         ]
     }
 

--- a/src/SkimDown/Viewer/MarkdownWebView.swift
+++ b/src/SkimDown/Viewer/MarkdownWebView.swift
@@ -193,9 +193,16 @@ final class MarkdownWebView: NSView, WKScriptMessageHandler, WKNavigationDelegat
     }
 
     func setReservedTrailingWidth(_ width: Double) {
-        let normalizedWidth = max(0, width)
+        let normalizedWidth = Self.normalizedReservedTrailingWidth(width)
         reservedTrailingWidth = normalizedWidth
         webView.evaluateJavaScript("window.skimdown && window.skimdown.setReservedTrailingWidth(\(normalizedWidth))")
+    }
+
+    static func normalizedReservedTrailingWidth(_ width: Double) -> Double {
+        guard width.isFinite else {
+            return 0
+        }
+        return max(0, width)
     }
 
     func showError(_ message: String, theme: AppTheme, resolvedTheme: ResolvedTheme?, fontSize: Double, completion: (() -> Void)? = nil) {

--- a/src/SkimDown/Viewer/MarkdownWebView.swift
+++ b/src/SkimDown/Viewer/MarkdownWebView.swift
@@ -6,6 +6,11 @@ struct SearchResult {
     let index: Int
 }
 
+struct PreviewLayoutMetrics {
+    let contentRight: Double
+    let viewportWidth: Double
+}
+
 @MainActor
 protocol MarkdownWebViewDelegate: AnyObject {
     func markdownWebView(_ webView: MarkdownWebView, didRequestLink href: String)
@@ -259,6 +264,18 @@ final class MarkdownWebView: NSView, WKScriptMessageHandler, WKNavigationDelegat
                 return
             }
             completion(rows.compactMap(TableOfContentsItem.init(javaScriptDictionary:)))
+        }
+    }
+
+    func previewLayoutMetrics(completion: @escaping (PreviewLayoutMetrics?) -> Void) {
+        webView.evaluateJavaScript("window.skimdown && window.skimdown.previewLayoutMetrics && window.skimdown.previewLayoutMetrics()") { value, _ in
+            guard let dictionary = value as? [String: Any],
+                  let contentRight = Self.doubleValue(dictionary["contentRight"]),
+                  let viewportWidth = Self.doubleValue(dictionary["viewportWidth"]) else {
+                completion(nil)
+                return
+            }
+            completion(PreviewLayoutMetrics(contentRight: contentRight, viewportWidth: viewportWidth))
         }
     }
 

--- a/src/SkimDown/Viewer/MarkdownWebView.swift
+++ b/src/SkimDown/Viewer/MarkdownWebView.swift
@@ -195,7 +195,7 @@ final class MarkdownWebView: NSView, WKScriptMessageHandler, WKNavigationDelegat
     func setReservedTrailingWidth(_ width: Double) {
         let normalizedWidth = Self.normalizedReservedTrailingWidth(width)
         reservedTrailingWidth = normalizedWidth
-        webView.evaluateJavaScript("window.skimdown && window.skimdown.setReservedTrailingWidth(\(normalizedWidth))")
+        applyReservedTrailingWidthToDocument()
     }
 
     static func normalizedReservedTrailingWidth(_ width: Double) -> Double {
@@ -462,10 +462,23 @@ final class MarkdownWebView: NSView, WKScriptMessageHandler, WKNavigationDelegat
 
         self.pendingNavigation = nil
         let completion = pendingNavigation.completion
+        let generation = pendingNavigation.generation
         if observedScrollY == nil {
             observedScrollY = pendingNavigation.scrollY ?? 0
         }
-        completion?()
+        applyReservedTrailingWidthToDocument { [weak self] in
+            guard let self,
+                  self.renderGeneration == generation else {
+                return
+            }
+            completion?()
+        }
+    }
+
+    private func applyReservedTrailingWidthToDocument(completion: (() -> Void)? = nil) {
+        webView.evaluateJavaScript("window.skimdown && window.skimdown.setReservedTrailingWidth(\(reservedTrailingWidth))") { _, _ in
+            completion?()
+        }
     }
 
     private static func buildHTML(payload: [String: Any], theme: AppTheme, resolvedTheme: ResolvedTheme?, katexFontsURL: String) throws -> String {

--- a/src/SkimDownTests/MarkdownWebViewTests.swift
+++ b/src/SkimDownTests/MarkdownWebViewTests.swift
@@ -1,0 +1,25 @@
+import XCTest
+@testable import SkimDown
+
+final class MarkdownWebViewTests: XCTestCase {
+    @MainActor
+    func testReservedTrailingWidthNormalizationKeepsFinitePositiveValues() {
+        XCTAssertEqual(MarkdownWebView.normalizedReservedTrailingWidth(300), 300)
+    }
+
+    @MainActor
+    func testReservedTrailingWidthNormalizationClampsNegativeValues() {
+        XCTAssertEqual(MarkdownWebView.normalizedReservedTrailingWidth(-42), 0)
+    }
+
+    @MainActor
+    func testReservedTrailingWidthNormalizationRejectsNaN() {
+        XCTAssertEqual(MarkdownWebView.normalizedReservedTrailingWidth(.nan), 0)
+    }
+
+    @MainActor
+    func testReservedTrailingWidthNormalizationRejectsInfinities() {
+        XCTAssertEqual(MarkdownWebView.normalizedReservedTrailingWidth(.infinity), 0)
+        XCTAssertEqual(MarkdownWebView.normalizedReservedTrailingWidth(-.infinity), 0)
+    }
+}

--- a/src/SkimDownTests/RendererAnchorTests.swift
+++ b/src/SkimDownTests/RendererAnchorTests.swift
@@ -723,6 +723,44 @@ final class RendererAnchorTests: XCTestCase {
     }
 
     @MainActor
+    func testReservedTrailingWidthSetterRejectsNonFiniteValues() async throws {
+        let webView = try await renderMarkdown(
+            """
+            # Reserved width sanitization
+
+            Non-finite JavaScript inputs should not leave stale CSS lengths.
+            """,
+            frameWidth: 1400,
+            includeStyles: true
+        )
+
+        let resultJSON = try await evaluateStringJavaScript(
+            """
+            (function () {
+              window.skimdown.setReservedTrailingWidth(300);
+              var finiteCSS = window.getComputedStyle(document.documentElement).getPropertyValue('--skimdown-reserved-trailing-width').trim();
+              window.skimdown.setReservedTrailingWidth(Infinity);
+              var infinityCSS = window.getComputedStyle(document.documentElement).getPropertyValue('--skimdown-reserved-trailing-width').trim();
+              window.skimdown.setReservedTrailingWidth(300);
+              window.skimdown.setReservedTrailingWidth(NaN);
+              var nanCSS = window.getComputedStyle(document.documentElement).getPropertyValue('--skimdown-reserved-trailing-width').trim();
+              return JSON.stringify({
+                finiteCSS: finiteCSS,
+                infinityCSS: infinityCSS,
+                nanCSS: nanCSS
+              });
+            })();
+            """,
+            in: webView
+        )
+        let result = try JSONDecoder().decode(ReservedWidthSanitizationResult.self, from: Data(resultJSON.utf8))
+
+        XCTAssertEqual(result.finiteCSS, "300px")
+        XCTAssertEqual(result.infinityCSS, "0px")
+        XCTAssertEqual(result.nanCSS, "0px")
+    }
+
+    @MainActor
     func testRenderPayloadPreservesReservedTrailingWidth() async throws {
         let webView = try await renderMarkdown(
             """
@@ -1198,6 +1236,12 @@ private struct ReservedWidthSetterResult: Decodable {
     let marker: String
     let reservedCSS: String
     let paddingRight: Double
+}
+
+private struct ReservedWidthSanitizationResult: Decodable {
+    let finiteCSS: String
+    let infinityCSS: String
+    let nanCSS: String
 }
 
 private struct TableLocalScrollResult: Decodable {

--- a/src/SkimDownTests/RendererAnchorTests.swift
+++ b/src/SkimDownTests/RendererAnchorTests.swift
@@ -666,12 +666,206 @@ final class RendererAnchorTests: XCTestCase {
     }
 
     @MainActor
+    func testNarrowTableKeepsNormalContentWidth() async throws {
+        let webView = try await renderMarkdown(
+            """
+            | Name | Value |
+            | --- | --- |
+            | One | Two |
+            """,
+            frameWidth: 1400,
+            includeStyles: true
+        )
+
+        let result = try await tableLayoutResult(in: webView)
+
+        XCTAssertFalse(result.isWide)
+        XCTAssertLessThanOrEqual(abs(result.wrapperWidth - result.contentWidth), 1.0)
+    }
+
+    @MainActor
+    func testWideTableExpandsBeyondContentColumnOnWideWindow() async throws {
+        let webView = try await renderMarkdown(
+            wideTableMarkdown(columnCount: 20),
+            frameWidth: 1400,
+            includeStyles: true
+        )
+
+        let result = try await tableLayoutResult(in: webView)
+
+        XCTAssertTrue(result.isWide)
+        XCTAssertGreaterThan(result.wrapperWidth, result.contentWidth + 100)
+    }
+
+    @MainActor
+    func testWideTableDoesNotExpandWhenWindowCannotGainWidth() async throws {
+        let webView = try await renderMarkdown(
+            wideTableMarkdown(columnCount: 20),
+            frameWidth: 800,
+            includeStyles: true
+        )
+
+        let result = try await tableLayoutResult(in: webView)
+
+        XCTAssertFalse(result.isWide)
+        XCTAssertLessThanOrEqual(abs(result.wrapperWidth - result.contentWidth), 1.0)
+        XCTAssertTrue(result.canScrollRight)
+    }
+
+    @MainActor
+    func testExpandedWideTableKeepsScrollCuesWhenStillOverflowing() async throws {
+        let webView = try await renderMarkdown(
+            wideTableMarkdown(columnCount: 40),
+            frameWidth: 1400,
+            includeStyles: true
+        )
+
+        let resultJSON = try await evaluateStringJavaScript(
+            """
+            (function () {
+              var wrapper = document.querySelector('.table-scroll');
+              var viewport = wrapper.querySelector('.table-scroll-viewport');
+              var initial = {
+                isWide: wrapper.classList.contains('table-scroll-wide'),
+                canScrollLeft: wrapper.classList.contains('can-scroll-left'),
+                canScrollRight: wrapper.classList.contains('can-scroll-right')
+              };
+              viewport.scrollLeft = viewport.scrollWidth;
+              viewport.dispatchEvent(new Event('scroll'));
+              return JSON.stringify({
+                initial: initial,
+                afterScroll: {
+                  canScrollLeft: wrapper.classList.contains('can-scroll-left'),
+                  canScrollRight: wrapper.classList.contains('can-scroll-right')
+                }
+              });
+            })();
+            """,
+            in: webView
+        )
+        let result = try JSONDecoder().decode(TableScrollCueResult.self, from: Data(resultJSON.utf8))
+
+        XCTAssertEqual(result.initial.isWide, true)
+        XCTAssertFalse(result.initial.canScrollLeft)
+        XCTAssertTrue(result.initial.canScrollRight)
+        XCTAssertTrue(result.afterScroll.canScrollLeft)
+        XCTAssertFalse(result.afterScroll.canScrollRight)
+    }
+
+    @MainActor
+    func testNestedWideTableAlignsWithBodyContentArea() async throws {
+        let quotedWideTable = wideTableMarkdown(columnCount: 20)
+            .split(separator: "\n")
+            .map { "> \($0)" }
+            .joined(separator: "\n")
+        let webView = try await renderMarkdown(
+            quotedWideTable,
+            frameWidth: 1400,
+            includeStyles: true
+        )
+
+        let resultJSON = try await evaluateStringJavaScript(
+            """
+            (function () {
+              var wrapper = document.querySelector('.table-scroll');
+              var rect = wrapper.getBoundingClientRect();
+              var bodyStyle = window.getComputedStyle(document.body);
+              var bodyLeft = parseFloat(bodyStyle.paddingLeft) || 0;
+              var bodyRight = window.innerWidth - (parseFloat(bodyStyle.paddingRight) || 0);
+              return JSON.stringify({
+                isWide: wrapper.classList.contains('table-scroll-wide'),
+                wrapperLeft: rect.left,
+                wrapperRight: rect.right,
+                bodyLeft: bodyLeft,
+                bodyRight: bodyRight
+              });
+            })();
+            """,
+            in: webView
+        )
+        let result = try JSONDecoder().decode(NestedTableAlignmentResult.self, from: Data(resultJSON.utf8))
+
+        XCTAssertTrue(result.isWide)
+        XCTAssertLessThanOrEqual(abs(result.wrapperLeft - result.bodyLeft), 1.0)
+        XCTAssertLessThanOrEqual(abs(result.wrapperRight - result.bodyRight), 1.0)
+    }
+
+    @MainActor
+    func testTableWideClassIsRecomputedAcrossRenders() async throws {
+        let webView = try await renderMarkdown(
+            wideTableMarkdown(columnCount: 20),
+            frameWidth: 1400,
+            includeStyles: true
+        )
+
+        let payload: [String: Any] = [
+            "markdown": """
+            | Name | Value |
+            | --- | --- |
+            | One | Two |
+            """,
+            "baseURL": Bundle.main.bundleURL.absoluteString,
+            "rootURL": Bundle.main.bundleURL.absoluteString,
+            "localFileScheme": LocalFileSchemeHandler.scheme,
+            "theme": "system",
+            "fontSize": 16,
+            "renderID": 2,
+            "restoreScrollY": 0
+        ]
+        let resultJSON = try await evaluateStringJavaScript(
+            """
+            window.skimdown.render(\(try jsonObject(payload)));
+            JSON.stringify({
+              wrapperCount: document.querySelectorAll('.table-scroll').length,
+              viewportCount: document.querySelectorAll('.table-scroll-viewport').length,
+              isWide: document.querySelector('.table-scroll').classList.contains('table-scroll-wide')
+            });
+            """,
+            in: webView
+        )
+        let result = try JSONDecoder().decode(TableRerenderResult.self, from: Data(resultJSON.utf8))
+
+        XCTAssertEqual(result.wrapperCount, 1)
+        XCTAssertEqual(result.viewportCount, 1)
+        XCTAssertFalse(result.isWide)
+    }
+
+    @MainActor
+    func testTableBecomesWideWhenContentGrowsAfterInitialRender() async throws {
+        let webView = try await renderMarkdown(
+            """
+            | Name | Value |
+            | --- | --- |
+            | One | Two |
+            """,
+            frameWidth: 1400,
+            includeStyles: true
+        )
+
+        _ = try await evaluateStringJavaScript(
+            """
+            (function () {
+              document.querySelector('table').style.minWidth = '1600px';
+              return 'mutated';
+            })();
+            """,
+            in: webView
+        )
+        let result = try await waitForTableLayout(in: webView) { $0.isWide }
+
+        XCTAssertTrue(result.isWide)
+        XCTAssertGreaterThan(result.wrapperWidth, result.contentWidth + 100)
+    }
+
+    @MainActor
     private func renderMarkdown(
         _ markdown: String,
         copyCodeMessageHandler: WKScriptMessageHandler? = nil,
         activeHeadingMessageHandler: WKScriptMessageHandler? = nil,
         additionalScripts: [String] = [],
-        additionalStyles: [String] = []
+        additionalStyles: [String] = [],
+        frameWidth: CGFloat = 800,
+        includeStyles: Bool = false
     ) async throws -> WKWebView {
         let configuration = WKWebViewConfiguration()
         if let copyCodeMessageHandler {
@@ -680,7 +874,7 @@ final class RendererAnchorTests: XCTestCase {
         if let activeHeadingMessageHandler {
             configuration.userContentController.add(activeHeadingMessageHandler, name: "activeHeading")
         }
-        let webView = WKWebView(frame: NSRect(x: 0, y: 0, width: 800, height: 1000), configuration: configuration)
+        let webView = WKWebView(frame: NSRect(x: 0, y: 0, width: frameWidth, height: 1000), configuration: configuration)
         let navigationDelegate = NavigationFinishedDelegate()
         let navigationFinished = expectation(description: "renderer HTML loads")
         navigationDelegate.onDidFinish = {
@@ -693,7 +887,12 @@ final class RendererAnchorTests: XCTestCase {
         webView.navigationDelegate = navigationDelegate
 
         webView.loadHTMLString(
-            try rendererHTML(markdown: markdown, additionalScripts: additionalScripts, additionalStyles: additionalStyles),
+            try rendererHTML(
+                markdown: markdown,
+                additionalScripts: additionalScripts,
+                additionalStyles: additionalStyles,
+                includeStyles: includeStyles
+            ),
             baseURL: Bundle.main.bundleURL
         )
         await fulfillment(of: [navigationFinished], timeout: 5)
@@ -702,7 +901,12 @@ final class RendererAnchorTests: XCTestCase {
         return webView
     }
 
-    private func rendererHTML(markdown: String, additionalScripts: [String] = [], additionalStyles: [String] = []) throws -> String {
+    private func rendererHTML(
+        markdown: String,
+        additionalScripts: [String] = [],
+        additionalStyles: [String] = [],
+        includeStyles: Bool = false
+    ) throws -> String {
         let baseScripts = try [
             "vendor/markdown-it/markdown-it.min.js",
             "vendor/dompurify/purify.min.js"
@@ -715,6 +919,11 @@ final class RendererAnchorTests: XCTestCase {
             additionalScripts +
             rendererScripts
         ).joined(separator: "\n")
+        var styleSources = additionalStyles
+        if includeStyles {
+            styleSources.insert(try readWebResource("skimdown.css"), at: 0)
+        }
+        let styles = styleSources.isEmpty ? "" : "<style>\(styleSources.joined(separator: "\n"))</style>"
 
         let payload: [String: Any] = [
             "markdown": markdown,
@@ -732,7 +941,8 @@ final class RendererAnchorTests: XCTestCase {
         <html>
           <head>
             <meta charset="utf-8">
-            <style>\(additionalStyles.joined(separator: "\n"))</style>
+            <meta name="viewport" content="width=device-width, initial-scale=1">
+            \(styles)
           </head>
           <body>
             <main id="content"></main>
@@ -741,6 +951,53 @@ final class RendererAnchorTests: XCTestCase {
           </body>
         </html>
         """
+    }
+
+    private func wideTableMarkdown(columnCount: Int) -> String {
+        let headers = (1...columnCount).map { "Column\($0)WideValue" }.joined(separator: " | ")
+        let separators = Array(repeating: "---", count: columnCount).joined(separator: " | ")
+        let values = (1...columnCount).map { "Cell\($0)WideValue" }.joined(separator: " | ")
+        return """
+        | \(headers) |
+        | \(separators) |
+        | \(values) |
+        """
+    }
+
+    @MainActor
+    private func tableLayoutResult(in webView: WKWebView) async throws -> TableLayoutResult {
+        let resultJSON = try await evaluateStringJavaScript(
+            """
+            (function () {
+              var wrapper = document.querySelector('.table-scroll');
+              var content = document.getElementById('content');
+              return JSON.stringify({
+                isWide: wrapper.classList.contains('table-scroll-wide'),
+                canScrollRight: wrapper.classList.contains('can-scroll-right'),
+                wrapperWidth: wrapper.getBoundingClientRect().width,
+                contentWidth: content.getBoundingClientRect().width
+              });
+            })();
+            """,
+            in: webView
+        )
+        return try JSONDecoder().decode(TableLayoutResult.self, from: Data(resultJSON.utf8))
+    }
+
+    @MainActor
+    private func waitForTableLayout(
+        in webView: WKWebView,
+        matching predicate: (TableLayoutResult) -> Bool
+    ) async throws -> TableLayoutResult {
+        var result = try await tableLayoutResult(in: webView)
+        for _ in 0..<40 {
+            if predicate(result) {
+                return result
+            }
+            try await Task.sleep(nanoseconds: 50_000_000)
+            result = try await tableLayoutResult(in: webView)
+        }
+        return result
     }
 
     private func readWebResource(_ relativePath: String) throws -> String {
@@ -923,6 +1180,38 @@ private struct TableOfContentsEntryResult: Decodable, Equatable {
 private struct ActiveHeadingMessage: Equatable {
     let renderID: Int
     let headingID: String?
+}
+
+private struct TableLayoutResult: Decodable {
+    let isWide: Bool
+    let canScrollRight: Bool
+    let wrapperWidth: Double
+    let contentWidth: Double
+}
+
+private struct TableScrollCueResult: Decodable {
+    let initial: TableScrollCueState
+    let afterScroll: TableScrollCueState
+}
+
+private struct TableScrollCueState: Decodable {
+    let isWide: Bool?
+    let canScrollLeft: Bool
+    let canScrollRight: Bool
+}
+
+private struct TableRerenderResult: Decodable {
+    let wrapperCount: Int
+    let viewportCount: Int
+    let isWide: Bool
+}
+
+private struct NestedTableAlignmentResult: Decodable {
+    let isWide: Bool
+    let wrapperLeft: Double
+    let wrapperRight: Double
+    let bodyLeft: Double
+    let bodyRight: Double
 }
 
 private struct CodeCopyFeedbackResult: Decodable {

--- a/src/SkimDownTests/RendererAnchorTests.swift
+++ b/src/SkimDownTests/RendererAnchorTests.swift
@@ -666,7 +666,103 @@ final class RendererAnchorTests: XCTestCase {
     }
 
     @MainActor
-    func testNarrowTableKeepsNormalContentWidth() async throws {
+    func testContentUsesExpandedPreviewWidth() async throws {
+        let webView = try await renderMarkdown(
+            """
+            # Wide preview
+
+            Paragraph content should use more than the old fixed 980px preview cap.
+            """,
+            frameWidth: 1400,
+            includeStyles: true
+        )
+
+        let result = try await previewLayoutResult(in: webView)
+
+        XCTAssertGreaterThan(result.contentWidth, 980)
+        XCTAssertLessThanOrEqual(abs(result.contentWidth - result.bodyContentWidth), 1.0)
+    }
+
+    @MainActor
+    func testReservedTrailingWidthSetterShrinksContentWithoutRerendering() async throws {
+        let webView = try await renderMarkdown(
+            """
+            # Reserved width
+
+            Content marker should survive a layout-only update.
+            """,
+            frameWidth: 1400,
+            includeStyles: true
+        )
+
+        let resultJSON = try await evaluateStringJavaScript(
+            """
+            (function () {
+              var content = document.getElementById('content');
+              var beforeWidth = content.getBoundingClientRect().width;
+              content.dataset.marker = 'kept';
+              window.skimdown.setReservedTrailingWidth(300);
+              var style = window.getComputedStyle(document.body);
+              return JSON.stringify({
+                beforeWidth: beforeWidth,
+                afterWidth: content.getBoundingClientRect().width,
+                marker: content.dataset.marker,
+                reservedCSS: window.getComputedStyle(document.documentElement).getPropertyValue('--skimdown-reserved-trailing-width').trim(),
+                paddingRight: parseFloat(style.paddingRight) || 0
+              });
+            })();
+            """,
+            in: webView
+        )
+        let result = try JSONDecoder().decode(ReservedWidthSetterResult.self, from: Data(resultJSON.utf8))
+
+        XCTAssertEqual(result.marker, "kept")
+        XCTAssertEqual(result.reservedCSS, "300px")
+        XCTAssertGreaterThanOrEqual(result.paddingRight, 300)
+        XCTAssertLessThan(result.afterWidth, result.beforeWidth)
+    }
+
+    @MainActor
+    func testRenderPayloadPreservesReservedTrailingWidth() async throws {
+        let webView = try await renderMarkdown(
+            """
+            # Reserved payload
+
+            This render starts with a reserved trailing width.
+            """,
+            frameWidth: 1400,
+            includeStyles: true,
+            reservedTrailingWidth: 300
+        )
+
+        let result = try await previewLayoutResult(in: webView)
+
+        XCTAssertEqual(result.reservedTrailingWidth, "300px")
+        XCTAssertGreaterThanOrEqual(result.paddingRight, 300)
+        XCTAssertLessThan(result.contentWidth, result.windowWidth - result.paddingLeft - 299)
+    }
+
+    @MainActor
+    func testZeroReservedTrailingWidthUsesFullAvailableContentArea() async throws {
+        let webView = try await renderMarkdown(
+            """
+            # Zero reserved width
+
+            The content should use the full body content area.
+            """,
+            frameWidth: 1400,
+            includeStyles: true
+        )
+
+        let result = try await previewLayoutResult(in: webView)
+
+        XCTAssertEqual(result.reservedTrailingWidth, "0px")
+        XCTAssertLessThan(result.paddingRight, 300)
+        XCTAssertLessThanOrEqual(abs(result.contentWidth - result.bodyContentWidth), 1.0)
+    }
+
+    @MainActor
+    func testReservedTrailingWidthSetterRecomputesTableScrollCues() async throws {
         let webView = try await renderMarkdown(
             """
             | Name | Value |
@@ -677,43 +773,32 @@ final class RendererAnchorTests: XCTestCase {
             includeStyles: true
         )
 
-        let result = try await tableLayoutResult(in: webView)
-
-        XCTAssertFalse(result.isWide)
-        XCTAssertLessThanOrEqual(abs(result.wrapperWidth - result.contentWidth), 1.0)
-    }
-
-    @MainActor
-    func testWideTableExpandsBeyondContentColumnOnWideWindow() async throws {
-        let webView = try await renderMarkdown(
-            wideTableMarkdown(columnCount: 20),
-            frameWidth: 1400,
-            includeStyles: true
+        let resultJSON = try await evaluateStringJavaScript(
+            """
+            (function () {
+              var wrapper = document.querySelector('.table-scroll');
+              var viewport = wrapper.querySelector('.table-scroll-viewport');
+              var table = wrapper.querySelector('table');
+              table.style.minWidth = '1100px';
+              window.skimdown.setReservedTrailingWidth(300);
+              return JSON.stringify({
+                viewportOverflows: viewport.scrollWidth > viewport.clientWidth + 1,
+                canScrollLeft: wrapper.classList.contains('can-scroll-left'),
+                canScrollRight: wrapper.classList.contains('can-scroll-right')
+              });
+            })();
+            """,
+            in: webView
         )
+        let result = try JSONDecoder().decode(TableCueState.self, from: Data(resultJSON.utf8))
 
-        let result = try await tableLayoutResult(in: webView)
-
-        XCTAssertTrue(result.isWide)
-        XCTAssertGreaterThan(result.wrapperWidth, result.contentWidth + 100)
-    }
-
-    @MainActor
-    func testWideTableDoesNotExpandWhenWindowCannotGainWidth() async throws {
-        let webView = try await renderMarkdown(
-            wideTableMarkdown(columnCount: 20),
-            frameWidth: 800,
-            includeStyles: true
-        )
-
-        let result = try await tableLayoutResult(in: webView)
-
-        XCTAssertFalse(result.isWide)
-        XCTAssertLessThanOrEqual(abs(result.wrapperWidth - result.contentWidth), 1.0)
+        XCTAssertTrue(result.viewportOverflows)
+        XCTAssertFalse(result.canScrollLeft)
         XCTAssertTrue(result.canScrollRight)
     }
 
     @MainActor
-    func testExpandedWideTableKeepsScrollCuesWhenStillOverflowing() async throws {
+    func testExtremelyWideTableKeepsLocalHorizontalScroll() async throws {
         let webView = try await renderMarkdown(
             wideTableMarkdown(columnCount: 40),
             frameWidth: 1400,
@@ -726,9 +811,13 @@ final class RendererAnchorTests: XCTestCase {
               var wrapper = document.querySelector('.table-scroll');
               var viewport = wrapper.querySelector('.table-scroll-viewport');
               var initial = {
-                isWide: wrapper.classList.contains('table-scroll-wide'),
+                wrapperCount: document.querySelectorAll('.table-scroll').length,
+                viewportCount: document.querySelectorAll('.table-scroll-viewport').length,
                 canScrollLeft: wrapper.classList.contains('can-scroll-left'),
-                canScrollRight: wrapper.classList.contains('can-scroll-right')
+                canScrollRight: wrapper.classList.contains('can-scroll-right'),
+                viewportOverflows: viewport.scrollWidth > viewport.clientWidth + 1,
+                pageScrollWidth: document.documentElement.scrollWidth,
+                windowWidth: window.innerWidth
               };
               viewport.scrollLeft = viewport.scrollWidth;
               viewport.dispatchEvent(new Event('scroll'));
@@ -743,118 +832,16 @@ final class RendererAnchorTests: XCTestCase {
             """,
             in: webView
         )
-        let result = try JSONDecoder().decode(TableScrollCueResult.self, from: Data(resultJSON.utf8))
+        let result = try JSONDecoder().decode(TableLocalScrollResult.self, from: Data(resultJSON.utf8))
 
-        XCTAssertEqual(result.initial.isWide, true)
+        XCTAssertEqual(result.initial.wrapperCount, 1)
+        XCTAssertEqual(result.initial.viewportCount, 1)
+        XCTAssertTrue(result.initial.viewportOverflows)
         XCTAssertFalse(result.initial.canScrollLeft)
         XCTAssertTrue(result.initial.canScrollRight)
         XCTAssertTrue(result.afterScroll.canScrollLeft)
         XCTAssertFalse(result.afterScroll.canScrollRight)
-    }
-
-    @MainActor
-    func testNestedWideTableAlignsWithBodyContentArea() async throws {
-        let quotedWideTable = wideTableMarkdown(columnCount: 20)
-            .split(separator: "\n")
-            .map { "> \($0)" }
-            .joined(separator: "\n")
-        let webView = try await renderMarkdown(
-            quotedWideTable,
-            frameWidth: 1400,
-            includeStyles: true
-        )
-
-        let resultJSON = try await evaluateStringJavaScript(
-            """
-            (function () {
-              var wrapper = document.querySelector('.table-scroll');
-              var rect = wrapper.getBoundingClientRect();
-              var bodyStyle = window.getComputedStyle(document.body);
-              var bodyLeft = parseFloat(bodyStyle.paddingLeft) || 0;
-              var bodyRight = window.innerWidth - (parseFloat(bodyStyle.paddingRight) || 0);
-              return JSON.stringify({
-                isWide: wrapper.classList.contains('table-scroll-wide'),
-                wrapperLeft: rect.left,
-                wrapperRight: rect.right,
-                bodyLeft: bodyLeft,
-                bodyRight: bodyRight
-              });
-            })();
-            """,
-            in: webView
-        )
-        let result = try JSONDecoder().decode(NestedTableAlignmentResult.self, from: Data(resultJSON.utf8))
-
-        XCTAssertTrue(result.isWide)
-        XCTAssertLessThanOrEqual(abs(result.wrapperLeft - result.bodyLeft), 1.0)
-        XCTAssertLessThanOrEqual(abs(result.wrapperRight - result.bodyRight), 1.0)
-    }
-
-    @MainActor
-    func testTableWideClassIsRecomputedAcrossRenders() async throws {
-        let webView = try await renderMarkdown(
-            wideTableMarkdown(columnCount: 20),
-            frameWidth: 1400,
-            includeStyles: true
-        )
-
-        let payload: [String: Any] = [
-            "markdown": """
-            | Name | Value |
-            | --- | --- |
-            | One | Two |
-            """,
-            "baseURL": Bundle.main.bundleURL.absoluteString,
-            "rootURL": Bundle.main.bundleURL.absoluteString,
-            "localFileScheme": LocalFileSchemeHandler.scheme,
-            "theme": "system",
-            "fontSize": 16,
-            "renderID": 2,
-            "restoreScrollY": 0
-        ]
-        let resultJSON = try await evaluateStringJavaScript(
-            """
-            window.skimdown.render(\(try jsonObject(payload)));
-            JSON.stringify({
-              wrapperCount: document.querySelectorAll('.table-scroll').length,
-              viewportCount: document.querySelectorAll('.table-scroll-viewport').length,
-              isWide: document.querySelector('.table-scroll').classList.contains('table-scroll-wide')
-            });
-            """,
-            in: webView
-        )
-        let result = try JSONDecoder().decode(TableRerenderResult.self, from: Data(resultJSON.utf8))
-
-        XCTAssertEqual(result.wrapperCount, 1)
-        XCTAssertEqual(result.viewportCount, 1)
-        XCTAssertFalse(result.isWide)
-    }
-
-    @MainActor
-    func testTableBecomesWideWhenContentGrowsAfterInitialRender() async throws {
-        let webView = try await renderMarkdown(
-            """
-            | Name | Value |
-            | --- | --- |
-            | One | Two |
-            """,
-            frameWidth: 1400,
-            includeStyles: true
-        )
-
-        _ = try await evaluateStringJavaScript(
-            """
-            (function () {
-              document.querySelector('table').style.minWidth = '1600px';
-              return 'mutated';
-            })();
-            """,
-            in: webView
-        )
-        let result = try await waitForTableLayout(in: webView) { $0.isWide }
-
-        XCTAssertTrue(result.isWide)
-        XCTAssertGreaterThan(result.wrapperWidth, result.contentWidth + 100)
+        XCTAssertLessThanOrEqual(result.initial.pageScrollWidth, result.initial.windowWidth + 1)
     }
 
     @MainActor
@@ -865,7 +852,8 @@ final class RendererAnchorTests: XCTestCase {
         additionalScripts: [String] = [],
         additionalStyles: [String] = [],
         frameWidth: CGFloat = 800,
-        includeStyles: Bool = false
+        includeStyles: Bool = false,
+        reservedTrailingWidth: Double = 0
     ) async throws -> WKWebView {
         let configuration = WKWebViewConfiguration()
         if let copyCodeMessageHandler {
@@ -891,7 +879,8 @@ final class RendererAnchorTests: XCTestCase {
                 markdown: markdown,
                 additionalScripts: additionalScripts,
                 additionalStyles: additionalStyles,
-                includeStyles: includeStyles
+                includeStyles: includeStyles,
+                reservedTrailingWidth: reservedTrailingWidth
             ),
             baseURL: Bundle.main.bundleURL
         )
@@ -905,7 +894,8 @@ final class RendererAnchorTests: XCTestCase {
         markdown: String,
         additionalScripts: [String] = [],
         additionalStyles: [String] = [],
-        includeStyles: Bool = false
+        includeStyles: Bool = false,
+        reservedTrailingWidth: Double = 0
     ) throws -> String {
         let baseScripts = try [
             "vendor/markdown-it/markdown-it.min.js",
@@ -933,7 +923,8 @@ final class RendererAnchorTests: XCTestCase {
             "theme": "system",
             "fontSize": 16,
             "renderID": 1,
-            "restoreScrollY": 0
+            "restoreScrollY": 0,
+            "reservedTrailingWidth": reservedTrailingWidth
         ]
 
         return """
@@ -965,39 +956,25 @@ final class RendererAnchorTests: XCTestCase {
     }
 
     @MainActor
-    private func tableLayoutResult(in webView: WKWebView) async throws -> TableLayoutResult {
+    private func previewLayoutResult(in webView: WKWebView) async throws -> PreviewLayoutResult {
         let resultJSON = try await evaluateStringJavaScript(
             """
             (function () {
-              var wrapper = document.querySelector('.table-scroll');
               var content = document.getElementById('content');
+              var bodyStyle = window.getComputedStyle(document.body);
               return JSON.stringify({
-                isWide: wrapper.classList.contains('table-scroll-wide'),
-                canScrollRight: wrapper.classList.contains('can-scroll-right'),
-                wrapperWidth: wrapper.getBoundingClientRect().width,
-                contentWidth: content.getBoundingClientRect().width
+                contentWidth: content.getBoundingClientRect().width,
+                paddingLeft: parseFloat(bodyStyle.paddingLeft) || 0,
+                paddingRight: parseFloat(bodyStyle.paddingRight) || 0,
+                bodyContentWidth: window.innerWidth - (parseFloat(bodyStyle.paddingLeft) || 0) - (parseFloat(bodyStyle.paddingRight) || 0),
+                windowWidth: window.innerWidth,
+                reservedTrailingWidth: window.getComputedStyle(document.documentElement).getPropertyValue('--skimdown-reserved-trailing-width').trim()
               });
             })();
             """,
             in: webView
         )
-        return try JSONDecoder().decode(TableLayoutResult.self, from: Data(resultJSON.utf8))
-    }
-
-    @MainActor
-    private func waitForTableLayout(
-        in webView: WKWebView,
-        matching predicate: (TableLayoutResult) -> Bool
-    ) async throws -> TableLayoutResult {
-        var result = try await tableLayoutResult(in: webView)
-        for _ in 0..<40 {
-            if predicate(result) {
-                return result
-            }
-            try await Task.sleep(nanoseconds: 50_000_000)
-            result = try await tableLayoutResult(in: webView)
-        }
-        return result
+        return try JSONDecoder().decode(PreviewLayoutResult.self, from: Data(resultJSON.utf8))
     }
 
     private func readWebResource(_ relativePath: String) throws -> String {
@@ -1182,36 +1159,47 @@ private struct ActiveHeadingMessage: Equatable {
     let headingID: String?
 }
 
-private struct TableLayoutResult: Decodable {
-    let isWide: Bool
-    let canScrollRight: Bool
-    let wrapperWidth: Double
+private struct PreviewLayoutResult: Decodable {
     let contentWidth: Double
+    let paddingLeft: Double
+    let paddingRight: Double
+    let bodyContentWidth: Double
+    let windowWidth: Double
+    let reservedTrailingWidth: String
 }
 
-private struct TableScrollCueResult: Decodable {
-    let initial: TableScrollCueState
-    let afterScroll: TableScrollCueState
+private struct ReservedWidthSetterResult: Decodable {
+    let beforeWidth: Double
+    let afterWidth: Double
+    let marker: String
+    let reservedCSS: String
+    let paddingRight: Double
 }
 
-private struct TableScrollCueState: Decodable {
-    let isWide: Bool?
+private struct TableLocalScrollResult: Decodable {
+    let initial: TableLocalScrollInitialState
+    let afterScroll: TableLocalScrollAfterState
+}
+
+private struct TableLocalScrollInitialState: Decodable {
+    let wrapperCount: Int
+    let viewportCount: Int
+    let viewportOverflows: Bool
+    let canScrollLeft: Bool
+    let canScrollRight: Bool
+    let pageScrollWidth: Double
+    let windowWidth: Double
+}
+
+private struct TableLocalScrollAfterState: Decodable {
     let canScrollLeft: Bool
     let canScrollRight: Bool
 }
 
-private struct TableRerenderResult: Decodable {
-    let wrapperCount: Int
-    let viewportCount: Int
-    let isWide: Bool
-}
-
-private struct NestedTableAlignmentResult: Decodable {
-    let isWide: Bool
-    let wrapperLeft: Double
-    let wrapperRight: Double
-    let bodyLeft: Double
-    let bodyRight: Double
+private struct TableCueState: Decodable {
+    let viewportOverflows: Bool
+    let canScrollLeft: Bool
+    let canScrollRight: Bool
 }
 
 private struct CodeCopyFeedbackResult: Decodable {

--- a/src/SkimDownTests/RendererAnchorTests.swift
+++ b/src/SkimDownTests/RendererAnchorTests.swift
@@ -762,6 +762,30 @@ final class RendererAnchorTests: XCTestCase {
     }
 
     @MainActor
+    func testPreviewLayoutMetricsReportsRenderedContentRect() async throws {
+        let webView = try await renderMarkdown(
+            """
+            # Layout metrics
+
+            The native TOC pane uses this content rect to stay near the rendered document.
+            """,
+            frameWidth: 1400,
+            includeStyles: true
+        )
+
+        let resultJSON = try await evaluateStringJavaScript(
+            "JSON.stringify(window.skimdown.previewLayoutMetrics());",
+            in: webView
+        )
+        let result = try JSONDecoder().decode(PreviewLayoutMetricsResult.self, from: Data(resultJSON.utf8))
+
+        XCTAssertEqual(result.viewportWidth, 1400, accuracy: 1)
+        XCTAssertGreaterThan(result.contentWidth, 0)
+        XCTAssertGreaterThan(result.contentRight, result.contentLeft)
+        XCTAssertLessThanOrEqual(result.contentRight, result.viewportWidth)
+    }
+
+    @MainActor
     func testReservedTrailingWidthSetterRecomputesTableScrollCues() async throws {
         let webView = try await renderMarkdown(
             """
@@ -1200,6 +1224,13 @@ private struct TableCueState: Decodable {
     let viewportOverflows: Bool
     let canScrollLeft: Bool
     let canScrollRight: Bool
+}
+
+private struct PreviewLayoutMetricsResult: Decodable {
+    let contentLeft: Double
+    let contentRight: Double
+    let contentWidth: Double
+    let viewportWidth: Double
 }
 
 private struct CodeCopyFeedbackResult: Decodable {

--- a/src/SkimDownTests/TableOfContentsPlacementTests.swift
+++ b/src/SkimDownTests/TableOfContentsPlacementTests.swift
@@ -58,7 +58,7 @@ final class TableOfContentsPlacementTests: XCTestCase {
             reservedTrailingWidth: 300
         )
 
-        XCTAssertEqual(contentRight, 1_100)
+        XCTAssertEqual(contentRight, 1_100, accuracy: 0.001)
     }
 
     func testEstimatedContentRightCentersBoundedContentOnUltrawideWindows() {
@@ -68,7 +68,7 @@ final class TableOfContentsPlacementTests: XCTestCase {
             reservedTrailingWidth: 300
         )
 
-        XCTAssertEqual(contentRight, 1_746)
+        XCTAssertEqual(contentRight, 1_746, accuracy: 0.001)
     }
 
     func testEstimatedContentRightScalesRemWithPreviewFontSize() {
@@ -78,6 +78,6 @@ final class TableOfContentsPlacementTests: XCTestCase {
             reservedTrailingWidth: 300
         )
 
-        XCTAssertEqual(contentRight, 2_698)
+        XCTAssertEqual(contentRight, 2_698, accuracy: 0.001)
     }
 }

--- a/src/SkimDownTests/TableOfContentsPlacementTests.swift
+++ b/src/SkimDownTests/TableOfContentsPlacementTests.swift
@@ -1,0 +1,83 @@
+import CoreGraphics
+import XCTest
+@testable import SkimDown
+
+final class TableOfContentsPlacementTests: XCTestCase {
+    func testLeadingOffsetPlacesPaneNextToContentWhenSpaceAllows() {
+        let leading = TableOfContentsPlacement.leadingOffset(
+            contentRight: 1_500,
+            containerWidth: 2_200,
+            paneWidth: 260,
+            trailingInset: 16,
+            gutter: 24
+        )
+
+        XCTAssertEqual(leading, 1_524)
+    }
+
+    func testLeadingOffsetClampsToTrailingEdgeWhenContentIsTooWide() {
+        let leading = TableOfContentsPlacement.leadingOffset(
+            contentRight: 800,
+            containerWidth: 1_000,
+            paneWidth: 260,
+            trailingInset: 16,
+            gutter: 24
+        )
+
+        XCTAssertEqual(leading, 724)
+    }
+
+    func testLeadingOffsetFallsBackToTrailingEdgeWithoutContentMetrics() {
+        let leading = TableOfContentsPlacement.leadingOffset(
+            contentRight: nil,
+            containerWidth: 1_400,
+            paneWidth: 260,
+            trailingInset: 16,
+            gutter: 24
+        )
+
+        XCTAssertEqual(leading, 1_124)
+    }
+
+    func testLeadingOffsetDoesNotReturnNegativeValueForNarrowContainers() {
+        let leading = TableOfContentsPlacement.leadingOffset(
+            contentRight: 80,
+            containerWidth: 180,
+            paneWidth: 260,
+            trailingInset: 16,
+            gutter: 24
+        )
+
+        XCTAssertEqual(leading, 0)
+    }
+
+    func testEstimatedContentRightFillsAvailableBodyWidthBeforeMaxWidth() {
+        let contentRight = PreviewContentLayout.estimatedContentRight(
+            containerWidth: 1_400,
+            fontSize: 16,
+            reservedTrailingWidth: 300
+        )
+
+        XCTAssertEqual(contentRight, 1_100)
+    }
+
+    func testEstimatedContentRightCentersBoundedContentOnUltrawideWindows() {
+        let contentRight = PreviewContentLayout.estimatedContentRight(
+            containerWidth: 2_200,
+            fontSize: 16,
+            reservedTrailingWidth: 300
+        )
+
+        XCTAssertEqual(contentRight, 1_746)
+    }
+
+    func testEstimatedContentRightScalesRemWithPreviewFontSize() {
+        let contentRight = PreviewContentLayout.estimatedContentRight(
+            containerWidth: 3_000,
+            fontSize: 28,
+            reservedTrailingWidth: 300
+        )
+
+        XCTAssertEqual(contentRight, 2_698)
+    }
+}


### PR DESCRIPTION
## Summary
- widen the Markdown preview layout so content uses available horizontal space instead of the old narrow cap
- reserve the floating TOC footprint only while the TOC is visible or expected during render, avoiding text overlap and layout jumps
- anchor the TOC beside the rendered content column on ultrawide windows, clamping to the safe trailing edge when needed
- keep wide tables locally scrollable and recompute table cues/active heading after layout-only changes

## Validation
- `make test`
- `make build`

Closes #45