### PR TITLE
Fix TOC overlay on expanded Mermaid diagrams

### DIFF
--- a/src/SkimDown/App/DocumentWindowController.swift
+++ b/src/SkimDown/App/DocumentWindowController.swift
@@ -31,6 +31,8 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, Side
     private var scrollPositions: [URL: Double] = [:]
     private var isInitialLayoutComplete = false
     private var hasLoadedTableOfContents = false
+    private var isMermaidModalPresented = false
+    private var reservesTableOfContentsWidthWhileLoading = false
     private var isTableOfContentsMetricsRequestInFlight = false
     private var needsTableOfContentsMetricsRefresh = false
 
@@ -435,6 +437,10 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, Side
         tableOfContentsViewController.setActiveHeadingID(headingID)
     }
 
+    func markdownWebView(_ webView: MarkdownWebView, didChangeMermaidModalPresentation isPresented: Bool) {
+        setMermaidModalPresentation(isPresented)
+    }
+
     func searchBarView(_ searchBarView: SearchBarView, didChangeQuery query: String, caseSensitive: Bool) {
         settings.isSearchCaseSensitive = caseSensitive
         settingsStore.isSearchCaseSensitive = caseSensitive
@@ -716,6 +722,7 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, Side
             sidebarViewController.selectFile(fileURL)
             emptyStateView.isHidden = true
             markdownWebView.isHidden = false
+            resetMermaidModalPresentation()
             clearTableOfContents(reserveWidthWhileLoading: settings.isTableOfContentsVisible)
             markdownWebView.render(
                 markdown: markdown,
@@ -735,6 +742,7 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, Side
             sidebarViewController.selectFile(fileURL)
             emptyStateView.isHidden = true
             markdownWebView.isHidden = false
+            resetMermaidModalPresentation()
             clearTableOfContents()
             markdownWebView.showError(
                 error.localizedDescription,
@@ -763,6 +771,7 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, Side
         emptyStateView.configure(state)
         emptyStateView.isHidden = false
         markdownWebView.isHidden = true
+        resetMermaidModalPresentation()
         clearTableOfContents()
         setSearchBarVisible(false)
         if session == nil {
@@ -778,6 +787,7 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, Side
                 return
             }
             self.hasLoadedTableOfContents = true
+            self.reservesTableOfContentsWidthWhileLoading = false
             self.tableOfContentsViewController.update(items: items)
             self.updateTableOfContentsHeight()
             self.updateTableOfContentsVisibility()
@@ -786,6 +796,7 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, Side
 
     private func clearTableOfContents(reserveWidthWhileLoading: Bool = false) {
         hasLoadedTableOfContents = false
+        reservesTableOfContentsWidthWhileLoading = reserveWidthWhileLoading
         tableOfContentsViewController.update(items: [])
         tableOfContentsViewController.setActiveHeadingID(nil)
         updateTableOfContentsHeight()
@@ -804,14 +815,38 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, Side
     }
 
     private func updateTableOfContentsVisibility(reserveWidthWhileLoading: Bool = false) {
-        let canShowTableOfContents = settings.isTableOfContentsVisible
-            && !markdownWebView.isHidden
-            && selectedFileURL != nil
-        let isVisible = canShowTableOfContents && hasLoadedTableOfContents
+        if reserveWidthWhileLoading {
+            reservesTableOfContentsWidthWhileLoading = true
+        }
+        let isVisible = TableOfContentsVisibility.shouldShowPane(
+            isSettingEnabled: settings.isTableOfContentsVisible,
+            isWebViewVisible: !markdownWebView.isHidden,
+            hasSelectedFile: selectedFileURL != nil,
+            hasLoadedTableOfContents: hasLoadedTableOfContents,
+            isMermaidModalPresented: isMermaidModalPresented
+        )
         tableOfContentsViewController.view.isHidden = !isVisible
-        let shouldReserveWidth = isVisible || (reserveWidthWhileLoading && canShowTableOfContents)
+        let shouldReserveWidth = TableOfContentsVisibility.shouldReserveTrailingWidth(
+            isSettingEnabled: settings.isTableOfContentsVisible,
+            isWebViewVisible: !markdownWebView.isHidden,
+            hasSelectedFile: selectedFileURL != nil,
+            hasLoadedTableOfContents: hasLoadedTableOfContents,
+            reserveWidthWhileLoading: reservesTableOfContentsWidthWhileLoading
+        )
         markdownWebView.setReservedTrailingWidth(shouldReserveWidth ? Self.tableOfContentsReservedTrailingWidth : 0)
         updateTableOfContentsPlacement()
+    }
+
+    private func setMermaidModalPresentation(_ isPresented: Bool) {
+        guard isMermaidModalPresented != isPresented else {
+            return
+        }
+        isMermaidModalPresented = isPresented
+        updateTableOfContentsVisibility()
+    }
+
+    private func resetMermaidModalPresentation() {
+        isMermaidModalPresented = false
     }
 
     private static var tableOfContentsReservedTrailingWidth: Double {

--- a/src/SkimDown/App/TableOfContentsPlacement.swift
+++ b/src/SkimDown/App/TableOfContentsPlacement.swift
@@ -17,6 +17,47 @@ enum TableOfContentsPlacement {
     }
 }
 
+enum TableOfContentsVisibility {
+    static func shouldShowPane(
+        isSettingEnabled: Bool,
+        isWebViewVisible: Bool,
+        hasSelectedFile: Bool,
+        hasLoadedTableOfContents: Bool,
+        isMermaidModalPresented: Bool
+    ) -> Bool {
+        canShowTableOfContents(
+            isSettingEnabled: isSettingEnabled,
+            isWebViewVisible: isWebViewVisible,
+            hasSelectedFile: hasSelectedFile
+        )
+        && hasLoadedTableOfContents
+        && !isMermaidModalPresented
+    }
+
+    static func shouldReserveTrailingWidth(
+        isSettingEnabled: Bool,
+        isWebViewVisible: Bool,
+        hasSelectedFile: Bool,
+        hasLoadedTableOfContents: Bool,
+        reserveWidthWhileLoading: Bool
+    ) -> Bool {
+        canShowTableOfContents(
+            isSettingEnabled: isSettingEnabled,
+            isWebViewVisible: isWebViewVisible,
+            hasSelectedFile: hasSelectedFile
+        )
+        && (hasLoadedTableOfContents || reserveWidthWhileLoading)
+    }
+
+    private static func canShowTableOfContents(
+        isSettingEnabled: Bool,
+        isWebViewVisible: Bool,
+        hasSelectedFile: Bool
+    ) -> Bool {
+        isSettingEnabled && isWebViewVisible && hasSelectedFile
+    }
+}
+
 enum PreviewContentLayout {
     private static let minimumInlinePadding: CGFloat = 40
     private static let preferredInlinePaddingRatio: CGFloat = 0.08

--- a/src/SkimDown/Resources/Web/renderer.js
+++ b/src/SkimDown/Resources/Web/renderer.js
@@ -19,6 +19,7 @@
   let activeHeadingRenderID = null;
   let lastActiveHeadingID = null;
   let activeMermaidModal = null;
+  let currentRenderID = null;
   let mermaidModalSequence = 0;
   const IMAGE_READY_TIMEOUT_MS = 3000;
   const CODE_COPY_FEEDBACK_RESET_MS = 1500;
@@ -111,6 +112,8 @@
   }
 
   function render(payload) {
+    const renderID = Number(payload.renderID);
+    currentRenderID = Number.isFinite(renderID) ? renderID : null;
     const restoreScrollY = Number(payload.restoreScrollY) || 0;
     if (restoreScrollY > 0) {
       document.body.classList.add("skimdown-restoring");
@@ -980,6 +983,7 @@
       ? activeElement
       : container;
     var modalID = "skimdown-mermaid-modal-" + (++mermaidModalSequence);
+    var modalRenderID = currentRenderID;
     var modal = document.createElement("div");
     modal.className = "mermaid-modal";
     modal.tabIndex = -1;
@@ -1057,6 +1061,7 @@
       document.documentElement.classList.remove("skimdown-mermaid-modal-open");
       document.body.classList.remove("skimdown-mermaid-modal-open");
       activeMermaidModal = null;
+      postMermaidModalState(false, modalRenderID);
       restoreMermaidModalFocus(opener, container);
     }
 
@@ -1073,10 +1078,11 @@
       handleMermaidModalKeydown(event, modal, closeModal);
     });
 
-    activeMermaidModal = { element: modal, close: closeModal };
+    activeMermaidModal = { element: modal, close: closeModal, renderID: modalRenderID };
     document.documentElement.classList.add("skimdown-mermaid-modal-open");
     document.body.classList.add("skimdown-mermaid-modal-open");
     document.body.appendChild(modal);
+    postMermaidModalState(true, modalRenderID);
 
     initMermaidZoomPan(modal, viewport, {
       wheelTarget: frame,
@@ -1984,6 +1990,15 @@
   function postRenderReady(renderID) {
     if (window.webkit && window.webkit.messageHandlers && window.webkit.messageHandlers.renderReady) {
       window.webkit.messageHandlers.renderReady.postMessage({ renderID: renderID });
+    }
+  }
+
+  function postMermaidModalState(isPresented, renderID) {
+    if (window.webkit && window.webkit.messageHandlers && window.webkit.messageHandlers.mermaidModalState) {
+      window.webkit.messageHandlers.mermaidModalState.postMessage({
+        renderID: renderID,
+        isPresented: Boolean(isPresented)
+      });
     }
   }
 

--- a/src/SkimDown/Resources/Web/renderer.js
+++ b/src/SkimDown/Resources/Web/renderer.js
@@ -121,7 +121,7 @@
     document.documentElement.dataset.theme = payload.theme || "system";
     document.documentElement.style.setProperty("--skimdown-font-size", String(payload.fontSize || 16) + "px");
     applyReservedTrailingWidth(payload.reservedTrailingWidth);
-    closeActiveMermaidModal();
+    closeActiveMermaidModal(currentRenderID);
 
     const content = document.getElementById("content");
     const dirtyHtml = renderer().render(payload.markdown || "");
@@ -1034,7 +1034,9 @@
       applyMermaidZoom(modal, viewport, 0.25);
       resizeHandler();
     });
-    closeButton.addEventListener("click", closeModal);
+    closeButton.addEventListener("click", function () {
+      closeModal();
+    });
 
     controls.appendChild(zoomOut);
     controls.appendChild(zoomReset);
@@ -1051,7 +1053,7 @@
     };
     var backdropMouseDown = false;
 
-    function closeModal() {
+    function closeModal(renderIDOverride) {
       if (!activeMermaidModal || activeMermaidModal.element !== modal) {
         return;
       }
@@ -1061,7 +1063,7 @@
       document.documentElement.classList.remove("skimdown-mermaid-modal-open");
       document.body.classList.remove("skimdown-mermaid-modal-open");
       activeMermaidModal = null;
-      postMermaidModalState(false, modalRenderID);
+      postMermaidModalState(false, renderIDOverride !== undefined ? renderIDOverride : modalRenderID);
       restoreMermaidModalFocus(opener, container);
     }
 
@@ -1078,7 +1080,7 @@
       handleMermaidModalKeydown(event, modal, closeModal);
     });
 
-    activeMermaidModal = { element: modal, close: closeModal, renderID: modalRenderID };
+    activeMermaidModal = { element: modal, close: closeModal };
     document.documentElement.classList.add("skimdown-mermaid-modal-open");
     document.body.classList.add("skimdown-mermaid-modal-open");
     document.body.appendChild(modal);
@@ -1102,9 +1104,9 @@
     });
   }
 
-  function closeActiveMermaidModal() {
+  function closeActiveMermaidModal(renderIDOverride) {
     if (activeMermaidModal) {
-      activeMermaidModal.close();
+      activeMermaidModal.close(renderIDOverride);
     }
   }
 

--- a/src/SkimDown/Viewer/MarkdownWebView.swift
+++ b/src/SkimDown/Viewer/MarkdownWebView.swift
@@ -16,6 +16,7 @@ protocol MarkdownWebViewDelegate: AnyObject {
     func markdownWebView(_ webView: MarkdownWebView, didRequestLink href: String)
     func markdownWebViewDidChangeEffectiveAppearance(_ webView: MarkdownWebView)
     func markdownWebView(_ webView: MarkdownWebView, didChangeActiveHeadingID headingID: String?)
+    func markdownWebView(_ webView: MarkdownWebView, didChangeMermaidModalPresentation isPresented: Bool)
 }
 
 @MainActor
@@ -45,6 +46,7 @@ final class MarkdownWebView: NSView, WKScriptMessageHandler, WKNavigationDelegat
         case userInteracted
         case scrollPosition
         case activeHeading
+        case mermaidModalState
     }
 
     private struct PendingNavigation {
@@ -349,6 +351,14 @@ final class MarkdownWebView: NSView, WKScriptMessageHandler, WKNavigationDelegat
             }
             let headingID = (body["headingID"] as? String).flatMap { $0.isEmpty ? nil : $0 }
             delegate?.markdownWebView(self, didChangeActiveHeadingID: headingID)
+        case .mermaidModalState:
+            guard let body = message.body as? [String: Any],
+                  let renderID = Self.intValue(body["renderID"]),
+                  renderID == renderGeneration,
+                  let isPresented = Self.boolValue(body["isPresented"]) else {
+                return
+            }
+            delegate?.markdownWebView(self, didChangeMermaidModalPresentation: isPresented)
         }
     }
 
@@ -723,6 +733,16 @@ final class MarkdownWebView: NSView, WKScriptMessageHandler, WKNavigationDelegat
         }
         if let number = value as? NSNumber {
             return number.doubleValue
+        }
+        return nil
+    }
+
+    private static func boolValue(_ value: Any?) -> Bool? {
+        if let bool = value as? Bool {
+            return bool
+        }
+        if let number = value as? NSNumber {
+            return number.boolValue
         }
         return nil
     }

--- a/src/SkimDownTests/TableOfContentsPlacementTests.swift
+++ b/src/SkimDownTests/TableOfContentsPlacementTests.swift
@@ -51,6 +51,78 @@ final class TableOfContentsPlacementTests: XCTestCase {
         XCTAssertEqual(leading, 0)
     }
 
+    func testTableOfContentsVisibilityShowsLoadedPaneWhenEnabled() {
+        let isVisible = TableOfContentsVisibility.shouldShowPane(
+            isSettingEnabled: true,
+            isWebViewVisible: true,
+            hasSelectedFile: true,
+            hasLoadedTableOfContents: true,
+            isMermaidModalPresented: false
+        )
+
+        XCTAssertTrue(isVisible)
+    }
+
+    func testTableOfContentsVisibilityHidesPaneWhileMermaidModalIsPresented() {
+        let isVisible = TableOfContentsVisibility.shouldShowPane(
+            isSettingEnabled: true,
+            isWebViewVisible: true,
+            hasSelectedFile: true,
+            hasLoadedTableOfContents: true,
+            isMermaidModalPresented: true
+        )
+
+        XCTAssertFalse(isVisible)
+    }
+
+    func testTableOfContentsVisibilityRequiresLoadedItems() {
+        let isVisible = TableOfContentsVisibility.shouldShowPane(
+            isSettingEnabled: true,
+            isWebViewVisible: true,
+            hasSelectedFile: true,
+            hasLoadedTableOfContents: false,
+            isMermaidModalPresented: false
+        )
+
+        XCTAssertFalse(isVisible)
+    }
+
+    func testTableOfContentsReserveWidthKeepsLoadedContentReserved() {
+        let shouldReserveWidth = TableOfContentsVisibility.shouldReserveTrailingWidth(
+            isSettingEnabled: true,
+            isWebViewVisible: true,
+            hasSelectedFile: true,
+            hasLoadedTableOfContents: true,
+            reserveWidthWhileLoading: false
+        )
+
+        XCTAssertTrue(shouldReserveWidth)
+    }
+
+    func testTableOfContentsReserveWidthCanReserveBeforeItemsLoad() {
+        let shouldReserveWidth = TableOfContentsVisibility.shouldReserveTrailingWidth(
+            isSettingEnabled: true,
+            isWebViewVisible: true,
+            hasSelectedFile: true,
+            hasLoadedTableOfContents: false,
+            reserveWidthWhileLoading: true
+        )
+
+        XCTAssertTrue(shouldReserveWidth)
+    }
+
+    func testTableOfContentsReserveWidthRequiresPreviewContext() {
+        let shouldReserveWidth = TableOfContentsVisibility.shouldReserveTrailingWidth(
+            isSettingEnabled: true,
+            isWebViewVisible: false,
+            hasSelectedFile: true,
+            hasLoadedTableOfContents: true,
+            reserveWidthWhileLoading: true
+        )
+
+        XCTAssertFalse(shouldReserveWidth)
+    }
+
     func testEstimatedContentRightFillsAvailableBodyWidthBeforeMaxWidth() {
         let contentRight = PreviewContentLayout.estimatedContentRight(
             containerWidth: 1_400,


### PR DESCRIPTION
## Summary
- hide the native table of contents pane while a Mermaid expanded modal is presented
- bridge Mermaid modal open/close state from the renderer to AppKit with render-generation filtering
- preserve TOC trailing-width reservation while TOC content is loading
- add unit coverage for TOC visibility and width-reservation decisions

Fixes #52

## Validation
- `make test`
- `make build`
- `make run` manual verification approved